### PR TITLE
feat(seguranca): implementar autorização por papéis (admin/user)

### DIFF
--- a/backend/src/main/java/com/vendaingressos/config/AdminBootstrapRunner.java
+++ b/backend/src/main/java/com/vendaingressos/config/AdminBootstrapRunner.java
@@ -1,0 +1,70 @@
+package com.vendaingressos.config;
+
+import com.vendaingressos.model.Administrador;
+import com.vendaingressos.model.enums.Role;
+import com.vendaingressos.repository.AdministradorRepository;
+import com.vendaingressos.repository.UsuarioRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AdminBootstrapRunner implements CommandLineRunner {
+
+    private final AdministradorRepository administradorRepository;
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${security.bootstrap-admin.enabled:false}")
+    private boolean enabled;
+
+    @Value("${security.bootstrap-admin.nome:}")
+    private String nome;
+
+    @Value("${security.bootstrap-admin.email:}")
+    private String email;
+
+    @Value("${security.bootstrap-admin.senha:}")
+    private String senha;
+
+    @Value("${security.bootstrap-admin.telefone:}")
+    private String telefone;
+
+    public AdminBootstrapRunner(
+            AdministradorRepository administradorRepository,
+            UsuarioRepository usuarioRepository,
+            PasswordEncoder passwordEncoder
+    ) {
+        this.administradorRepository = administradorRepository;
+        this.usuarioRepository = usuarioRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        if (!enabled) {
+            return;
+        }
+        if (administradorRepository.count() > 0) {
+            return;
+        }
+        if (email == null || email.isBlank() || senha == null || senha.isBlank()) {
+            return;
+        }
+        if (usuarioRepository.findByEmail(email).isPresent()) {
+            throw new IllegalStateException("Email do bootstrap admin já está em uso por usuário: " + email);
+        }
+
+        Administrador admin = new Administrador();
+        admin.setNome((nome == null || nome.isBlank()) ? "Admin Bootstrap" : nome);
+        admin.setEmail(email);
+        admin.setSenha(passwordEncoder.encode(senha));
+        admin.setTelefone((telefone == null) ? "" : telefone);
+        admin.setRole(Role.ADMINISTRADOR);
+
+        administradorRepository.save(admin);
+    }
+}

--- a/backend/src/main/java/com/vendaingressos/config/AdminBootstrapRunner.java
+++ b/backend/src/main/java/com/vendaingressos/config/AdminBootstrapRunner.java
@@ -9,6 +9,8 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component
 public class AdminBootstrapRunner implements CommandLineRunner {
@@ -16,6 +18,8 @@ public class AdminBootstrapRunner implements CommandLineRunner {
     private final AdministradorRepository administradorRepository;
     private final UsuarioRepository usuarioRepository;
     private final PasswordEncoder passwordEncoder;
+
+    private static final Logger log = LoggerFactory.getLogger(AdminBootstrapRunner.class);
 
     @Value("${security.bootstrap-admin.enabled:false}")
     private boolean enabled;
@@ -55,7 +59,8 @@ public class AdminBootstrapRunner implements CommandLineRunner {
             return;
         }
         if (usuarioRepository.findByEmail(email).isPresent()) {
-            throw new IllegalStateException("Email do bootstrap admin já está em uso por usuário: " + email);
+            log.warn("Bootstrap admin ignorado: email já existe em Usuario: {}", email);
+            return;
         }
 
         Administrador admin = new Administrador();

--- a/backend/src/main/java/com/vendaingressos/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/vendaingressos/config/OpenApiConfig.java
@@ -5,8 +5,12 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.PathItem;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
@@ -26,5 +30,68 @@ public class OpenApiConfig {
                                         .type(SecurityScheme.Type.HTTP)
                                         .scheme("bearer")
                                         .bearerFormat("JWT")));
+    }
+
+    @Bean
+    public OpenApiCustomizer rolesOpenApiCustomizer() {
+        return openApi -> {
+            if (openApi.getPaths() == null) {
+                return;
+            }
+
+            openApi.getPaths().forEach((path, pathItem) -> {
+                pathItem.readOperationsMap().forEach((method, operation) -> {
+                    if (isPublic(path, method)) {
+                        operation.setSecurity(List.of());
+                        return;
+                    }
+
+                    operation.addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+                    List<String> roles = resolveRoles(path, method);
+                    if (!roles.isEmpty()) {
+                        operation.addExtension("x-roles", roles);
+                    }
+                });
+            });
+        };
+    }
+
+    private boolean isPublic(String path, PathItem.HttpMethod method) {
+        if (path.startsWith("/api/auth")) {
+            return true;
+        }
+        if (path.startsWith("/v3/api-docs") || path.startsWith("/swagger-ui")) {
+            return true;
+        }
+        if (path.startsWith("/api/eventos") && method == PathItem.HttpMethod.GET) {
+            return true;
+        }
+        return path.equals("/api/usuarios") && method == PathItem.HttpMethod.POST;
+    }
+
+    private List<String> resolveRoles(String path, PathItem.HttpMethod method) {
+        if (path.startsWith("/api/eventos")) {
+            if (method == PathItem.HttpMethod.POST || method == PathItem.HttpMethod.PUT || method == PathItem.HttpMethod.DELETE) {
+                return List.of("ROLE_ADMIN");
+            }
+        }
+        if (path.startsWith("/api/sessoes-evento")
+                || path.startsWith("/api/tipos-ingresso")
+                || path.startsWith("/api/administradores")
+                || path.startsWith("/ingressos")) {
+            return List.of("ROLE_ADMIN");
+        }
+        if (path.startsWith("/api/usuarios")) {
+            if (path.equals("/api/usuarios/me") || path.equals("/api/usuarios/meus-ingressos")) {
+                return List.of("ROLE_USER", "ROLE_ADMIN");
+            }
+            if (method != PathItem.HttpMethod.POST) {
+                return List.of("ROLE_ADMIN");
+            }
+        }
+        if (path.startsWith("/api/compras") || path.startsWith("/api/transferencias")) {
+            return List.of("ROLE_USER", "ROLE_ADMIN");
+        }
+        return List.of();
     }
 }

--- a/backend/src/main/java/com/vendaingressos/config/SecurityConfig.java
+++ b/backend/src/main/java/com/vendaingressos/config/SecurityConfig.java
@@ -16,7 +16,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
@@ -35,10 +34,31 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(authorize -> authorize
+                        //publicos
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/usuarios").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/eventos/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+
+                        //usuarios
+                        .requestMatchers(HttpMethod.GET, "/api/usuarios/me").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/usuarios/me").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/usuarios/meus-ingressos").hasAnyRole("USER", "ADMIN")
+
+                        //admin
+                        .requestMatchers(HttpMethod.POST, "/api/eventos/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/eventos/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/eventos/**").hasRole("ADMIN")
+                        .requestMatchers("/api/sessoes-evento/**").hasRole("ADMIN")
+                        .requestMatchers("/api/tipos-ingresso/**").hasRole("ADMIN")
+                        .requestMatchers("/api/administradores/**").hasRole("ADMIN")
+                        .requestMatchers("/ingressos/**").hasRole("ADMIN")
+                        .requestMatchers("/api/usuarios/**").hasRole("ADMIN")
+
+                        // autenticados (user/admin)
+                        .requestMatchers("/api/compras/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/transferencias/**").hasAnyRole("USER", "ADMIN")
+
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/backend/src/main/java/com/vendaingressos/controller/UsuarioController.java
+++ b/backend/src/main/java/com/vendaingressos/controller/UsuarioController.java
@@ -1,6 +1,8 @@
 package com.vendaingressos.controller;
 
+import com.vendaingressos.dto.UsuarioCreateRequest;
 import com.vendaingressos.dto.UsuarioResponse;
+import com.vendaingressos.dto.UsuarioUpdateRequest;
 import com.vendaingressos.exception.ResourceNotFoundException;
 import com.vendaingressos.model.Usuario;
 import com.vendaingressos.service.UsuarioService;
@@ -8,6 +10,7 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,8 +30,8 @@ public class UsuarioController {
 
     // Endpoint para cadastrar um novo usuário (POST /api/usuarios)
     @PostMapping
-    public ResponseEntity<UsuarioResponse> cadastrarUsuario(@Valid @RequestBody Usuario usuario) {
-        Usuario novoUsuario = usuarioService.cadastrarUsuario(usuario);
+    public ResponseEntity<UsuarioResponse> cadastrarUsuario(@Valid @RequestBody UsuarioCreateRequest dto) {
+        Usuario novoUsuario = usuarioService.cadastrarUsuario(dto);
         return new ResponseEntity<>(new UsuarioResponse(novoUsuario), HttpStatus.CREATED);
     }
 
@@ -57,8 +60,8 @@ public class UsuarioController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<UsuarioResponse> atualizarUsuario(@PathVariable Long id, @Valid @RequestBody Usuario usuario) {
-        Usuario usuarioAtualizado = usuarioService.atualizarUsuario(id, usuario);
+    public ResponseEntity<UsuarioResponse> atualizarUsuario(@PathVariable Long id, @Valid @RequestBody UsuarioUpdateRequest dto) {
+        Usuario usuarioAtualizado = usuarioService.atualizarUsuario(id, dto);
         return new ResponseEntity<>(new UsuarioResponse(usuarioAtualizado), HttpStatus.OK);
     }
 
@@ -66,5 +69,22 @@ public class UsuarioController {
     public ResponseEntity<Void> deletarUsuario(@PathVariable Long id) {
         usuarioService.deletarUsuario(id);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UsuarioResponse> meuPerfil(Authentication authentication) {
+        String email = authentication.getName();
+        Usuario usuario = usuarioService.buscarUsuarioPorEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário autenticado não encontrado."));
+        return ResponseEntity.ok(new UsuarioResponse(usuario));
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<UsuarioResponse> atualizarMeuPerfil(Authentication authentication, @Valid @RequestBody UsuarioUpdateRequest dto) {
+        String email = authentication.getName();
+        Usuario atual = usuarioService.buscarUsuarioPorEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário autenticado não encontrado."));
+        Usuario atualizado = usuarioService.atualizarUsuario(atual.getIdUsuario(), dto);
+        return ResponseEntity.ok(new UsuarioResponse(atualizado));
     }
 }

--- a/backend/src/main/java/com/vendaingressos/dto/UsuarioCreateRequest.java
+++ b/backend/src/main/java/com/vendaingressos/dto/UsuarioCreateRequest.java
@@ -1,0 +1,38 @@
+package com.vendaingressos.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDate;
+
+public record UsuarioCreateRequest(
+
+        @NotBlank(message = "O nome não pode estar em branco")
+        String nome,
+
+        @NotBlank(message = "O CPF não pode estar em branco")
+        @Size(min = 11, max = 11, message = "O CPF deve conter 11 dígitos.")
+        @Pattern(regexp = "\\d{11}", message = "O CPF deve conter apenas 11 dígitos numéricos.")
+        @JsonProperty("CPF")
+        String cpf,
+
+        @NotNull(message = "A data de nascimento não pode ser nula")
+        @Past
+        LocalDate dataNascimento,
+
+        @NotBlank(message = "O email não pode estar em branco")
+        @Email(message = "Formato de email inválido")
+        String email,
+
+        @NotBlank(message = "A senha não pode estar em branco")
+        String senha,
+
+        @NotBlank(message = "O endereço não pode estar em branco")
+        String endereco,
+
+        @NotBlank(message = "O telefone não pode estar em branco")
+        @Pattern(regexp = "^\\(?([0-9]{2})\\)?[-. ]?([0-9]{4,5})[-. ]?([0-9]{4})$",
+                message = "Formato de telefone inválido. Use (XX) XXXX-XXXX ou (XX) XXXXX-XXXX")
+        String telefone)
+{
+}

--- a/backend/src/main/java/com/vendaingressos/dto/UsuarioUpdateRequest.java
+++ b/backend/src/main/java/com/vendaingressos/dto/UsuarioUpdateRequest.java
@@ -17,7 +17,6 @@ public record UsuarioUpdateRequest(
         @Email(message = "Formato de email inválido")
         String email,
 
-        @Size(min = 8, message = "A senha deve ter no mínimo 8 caracteres")
         String senha,
 
         String endereco,

--- a/backend/src/main/java/com/vendaingressos/dto/UsuarioUpdateRequest.java
+++ b/backend/src/main/java/com/vendaingressos/dto/UsuarioUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.vendaingressos.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+
+import java.time.LocalDate;
+
+public record UsuarioUpdateRequest(
+        String nome,
+
+        @Past
+        LocalDate dataNascimento,
+
+        @Email(message = "Formato de email inválido")
+        String email,
+
+        @Size(min = 8, message = "A senha deve ter no mínimo 8 caracteres")
+        String senha,
+
+        String endereco,
+
+        @Pattern(
+                regexp = "^\\(?([0-9]{2})\\)?[-. ]?([0-9]{4,5})[-. ]?([0-9]{4})$",
+                message = "Formato de telefone inválido. Use (XX) XXXX-XXXX ou (XX) XXXXX-XXXX"
+        )
+        String telefone
+) {
+}

--- a/backend/src/main/java/com/vendaingressos/model/Administrador.java
+++ b/backend/src/main/java/com/vendaingressos/model/Administrador.java
@@ -1,6 +1,8 @@
 package com.vendaingressos.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.vendaingressos.model.enums.Role;
+import lombok.*;
 
 import java.util.Objects;
 
@@ -9,6 +11,12 @@ import java.util.List;
 
 @Entity
 @Table(name = "administrador")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
 public class Administrador {
 
     @Id
@@ -23,6 +31,10 @@ public class Administrador {
 
     private String telefone;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role = Role.ADMINISTRADOR;
+
     @OneToMany(
             mappedBy = "administrador",
             cascade = CascadeType.ALL,
@@ -30,81 +42,4 @@ public class Administrador {
             fetch = FetchType.LAZY
     )
     private List<Evento> eventosCriados = new ArrayList<>();
-
-    public Administrador() {}
-
-    public Administrador( String nome, String email, String senha, String telefone) {
-        this.nome = nome;
-        this.email = email;
-        this.senha = senha;
-        this.telefone = telefone;
-    }
-
-    public Long getIdAdmin() {
-        return idAdmin;
-    }
-
-    public void setIdAdmin(Long idAdmin) {
-        this.idAdmin = idAdmin;
-    }
-    public String getNome() {
-        return nome;
-    }
-    public void setNome(String nome) {
-        this.nome = nome;
-    }
-    public String getEmail() {
-        return email;
-    }
-    public void setEmail(String email) {
-        this.email = email;
-    }
-    public String getSenha() {
-        return senha;
-    }
-    public void setSenha(String senha) {
-        this.senha = senha;
-    }
-    public String getTelefone() {
-        return telefone;
-    }
-    public void setTelefone(String telefone) {
-        this.telefone = telefone;
-    }
-
-    public List<Evento> getEventosCriados() {
-        return eventosCriados;
-    }
-    public void setEventosCriados(List<Evento> eventosCriados) {
-        this.eventosCriados = eventosCriados;
-    }
-    public void addEventoCriado(Evento e) {
-        eventosCriados.add(e);
-        e.setAdministrador(this);
-    }
-    public void removeEventoCriado(Evento e) {
-        eventosCriados.remove(e);
-        e.setAdministrador(null);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) return false;
-        Administrador that = (Administrador) o;
-        return Objects.equals(idAdmin, that.idAdmin);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(idAdmin);
-    }
-
-    @Override
-    public String toString() {
-        return "Administrador{" +
-                "idAdmin=" + idAdmin +
-                ", nome='" + nome + '\'' +
-                ", email='" + email + '\'' +
-                '}';
-    }
 }

--- a/backend/src/main/java/com/vendaingressos/model/Administrador.java
+++ b/backend/src/main/java/com/vendaingressos/model/Administrador.java
@@ -15,8 +15,6 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 @Setter
-@EqualsAndHashCode
-@ToString
 public class Administrador {
 
     @Id
@@ -42,4 +40,25 @@ public class Administrador {
             fetch = FetchType.LAZY
     )
     private List<Evento> eventosCriados = new ArrayList<>();
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Administrador that = (Administrador) o;
+        return Objects.equals(idAdmin, that.idAdmin);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(idAdmin);
+    }
+
+    @Override
+    public String toString() {
+        return "Administrador{" +
+                "idAdmin=" + idAdmin +
+                ", nome='" + nome + '\'' +
+                ", email='" + email + '\'' +
+                '}';
+    }
 }

--- a/backend/src/main/java/com/vendaingressos/model/Usuario.java
+++ b/backend/src/main/java/com/vendaingressos/model/Usuario.java
@@ -4,12 +4,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import com.vendaingressos.model.enums.Role;
 
 import java.time.LocalDate;
-import java.util.UUID;
 
 @Entity
 @Table(name = "usuario")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
 public class Usuario {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,81 +47,7 @@ public class Usuario {
             message = "Formato de telefone inválido. Use (XX) XXXX-XXXX ou (XX) XXXXX-XXXX")
     private String telefone;
 
-    public Usuario() {
-    }
-
-    public Usuario(Long idUsuario, String nome, String cpf, LocalDate dataNascimento, String email, String senha, String endereco, String telefone) {
-        this.idUsuario = idUsuario;
-        this.nome = nome;
-        this.cpf = cpf;
-        this.dataNascimento = dataNascimento;
-        this.email = email;
-        this.senha = senha;
-        this.endereco = endereco;
-        this.telefone = telefone;
-    }
-
-    public Long getIdUsuario() {
-        return idUsuario;
-    }
-
-    public void setIdUsuario(Long idUsuario) {
-        this.idUsuario = idUsuario;
-    }
-
-    public String getNome() {
-        return nome;
-    }
-
-    public void setNome(String nome) {
-        this.nome = nome;
-    }
-
-    public String getCpf() {
-        return cpf;
-    }
-
-    public void setCpf(String cpf) {
-        this.cpf = cpf;
-    }
-
-    public LocalDate getDataNascimento() {
-        return dataNascimento;
-    }
-
-    public void setDataNascimento(LocalDate dataNascimento) {
-        this.dataNascimento = dataNascimento;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getSenha() {
-        return senha;
-    }
-
-    public void setSenha(String senha) {
-        this.senha = senha;
-    }
-
-    public String getEndereco() {
-        return endereco;
-    }
-
-    public void setEndereco(String endereco) {
-        this.endereco = endereco;
-    }
-
-    public String getTelefone() {
-        return telefone;
-    }
-
-    public void setTelefone(String telefone) {
-        this.telefone = telefone;
-    }
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role = Role.USUARIO;
 }

--- a/backend/src/main/java/com/vendaingressos/model/enums/Role.java
+++ b/backend/src/main/java/com/vendaingressos/model/enums/Role.java
@@ -1,0 +1,6 @@
+package com.vendaingressos.model.enums;
+
+public enum Role {
+    USUARIO,
+    ADMINISTRADOR
+}

--- a/backend/src/main/java/com/vendaingressos/service/AdministradorService.java
+++ b/backend/src/main/java/com/vendaingressos/service/AdministradorService.java
@@ -1,9 +1,11 @@
 package com.vendaingressos.service;
 
+import com.vendaingressos.exception.BadRequestException;
 import com.vendaingressos.exception.ResourceNotFoundException;
 import com.vendaingressos.model.Administrador;
-import com.vendaingressos.repository.AdministradorRepository; // Necessário criar a interface JpaRepository
-import org.springframework.beans.factory.annotation.Autowired;
+import com.vendaingressos.model.enums.Role;
+import com.vendaingressos.repository.AdministradorRepository;
+import com.vendaingressos.repository.UsuarioRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,15 +15,23 @@ import java.util.List;
 @Service
 public class AdministradorService {
 
-    @Autowired
-    private AdministradorRepository administradorRepository;
+    private final AdministradorRepository administradorRepository;
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    public AdministradorService(AdministradorRepository administradorRepository, UsuarioRepository usuarioRepository, PasswordEncoder passwordEncoder) {
+        this.administradorRepository = administradorRepository;
+        this.usuarioRepository = usuarioRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
 
     @Transactional
     public Administrador cadastrar(Administrador admin) {
+        if (administradorRepository.findByEmail(admin.getEmail()).isPresent() || usuarioRepository.findByEmail(admin.getEmail()).isPresent()) {
+            throw new BadRequestException("Já existe um cadastro com este e-mail.");
+        }
         admin.setSenha(passwordEncoder.encode(admin.getSenha()));
+        admin.setRole(Role.ADMINISTRADOR);
         return administradorRepository.save(admin);
     }
 

--- a/backend/src/main/java/com/vendaingressos/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/vendaingressos/service/CustomUserDetailsService.java
@@ -1,8 +1,10 @@
 package com.vendaingressos.service;
 
+import com.vendaingressos.model.Administrador;
 import com.vendaingressos.model.Usuario;
+import com.vendaingressos.model.enums.Role;
+import com.vendaingressos.repository.AdministradorRepository;
 import com.vendaingressos.repository.UsuarioRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -10,27 +12,43 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UsuarioRepository usuarioRepository;
+    private final AdministradorRepository administradorRepository;
 
-    @Autowired
-    public CustomUserDetailsService(UsuarioRepository usuarioRepository) {
+    public CustomUserDetailsService(UsuarioRepository usuarioRepository, AdministradorRepository administradorRepository) {
         this.usuarioRepository = usuarioRepository;
+        this.administradorRepository = administradorRepository;
     }
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Usuario usuario = usuarioRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado com e-mail: " + email));
+        Usuario usuario = usuarioRepository.findByEmail(email).orElse(null);
+        if (usuario != null) {
+            String role = mapRole(usuario.getRole(), Role.USUARIO);
+            return new User(usuario.getEmail(), usuario.getSenha(), List.of(new SimpleGrantedAuthority(role))
+            );
+        }
 
-        List<SimpleGrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+        Administrador admin = administradorRepository.findByEmail(email).orElse(null);
+        if (admin != null) {
+            String role = mapRole(admin.getRole(), Role.ADMINISTRADOR);
+            return new User(admin.getEmail(), admin.getSenha(), List.of(new SimpleGrantedAuthority(role))
+            );
+        }
 
-        // A próxima evolução seria adicionar um campo 'role' no modelo de Usuario.
-        return new User(usuario.getEmail(), usuario.getSenha(), authorities);
+        throw new UsernameNotFoundException("Usuário não encontrado com e-mail: " + email);
+    }
+
+    private String mapRole(Role role, Role fallback) {
+        Role resolved = role == null ? fallback : role;
+        if (resolved == Role.ADMINISTRADOR) {
+            return "ROLE_ADMIN";
+        }
+        return "ROLE_USER";
     }
 }

--- a/backend/src/main/java/com/vendaingressos/service/UsuarioService.java
+++ b/backend/src/main/java/com/vendaingressos/service/UsuarioService.java
@@ -1,10 +1,14 @@
 package com.vendaingressos.service;
 
+import com.vendaingressos.dto.UsuarioCreateRequest;
+import com.vendaingressos.dto.UsuarioUpdateRequest;
 import com.vendaingressos.exception.BadRequestException;
 import com.vendaingressos.exception.ResourceNotFoundException;
 import com.vendaingressos.model.Compra;
 import com.vendaingressos.model.Ingresso;
 import com.vendaingressos.model.Usuario;
+import com.vendaingressos.model.enums.Role;
+import com.vendaingressos.repository.AdministradorRepository;
 import com.vendaingressos.repository.UsuarioRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -13,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,20 +26,32 @@ public class UsuarioService {
     private final UsuarioRepository usuarioRepository;
     private final PasswordEncoder passwordEncoder;
     private final CompraService compraService;
+    private final AdministradorRepository administradorRepository;
 
     @Autowired
-    public UsuarioService(UsuarioRepository usuarioRepository, PasswordEncoder passwordEncoder, CompraService compraService){
+    public UsuarioService(UsuarioRepository usuarioRepository, PasswordEncoder passwordEncoder, CompraService compraService, AdministradorRepository administradorRepository){
         this.usuarioRepository = usuarioRepository;
         this.passwordEncoder = passwordEncoder;
         this.compraService = compraService;
+        this.administradorRepository = administradorRepository;
     }
 
     @Transactional
-    public Usuario cadastrarUsuario(Usuario usuario) {
-        if (usuarioRepository.findByEmail(usuario.getEmail()).isPresent()) {
-            throw new BadRequestException("Já existe um usuário cadastrado com este e-mail.");
+    public Usuario cadastrarUsuario(UsuarioCreateRequest dto) {
+        if (usuarioRepository.findByEmail(dto.email()).isPresent() || administradorRepository.findByEmail(dto.email()).isPresent()) {
+            throw new BadRequestException("Já existe um usuário ou administrador cadastrado com este e-mail.");
         }
-        usuario.setSenha(passwordEncoder.encode(usuario.getSenha()));
+
+        Usuario usuario = new Usuario();
+        usuario.setNome(dto.nome());
+        usuario.setCpf(dto.cpf());
+        usuario.setDataNascimento(dto.dataNascimento());
+        usuario.setEmail(dto.email());
+        usuario.setSenha(passwordEncoder.encode(dto.senha()));
+        usuario.setEndereco(dto.endereco());
+        usuario.setTelefone(dto.telefone());
+        usuario.setRole(Role.USUARIO);
+
         return usuarioRepository.save(usuario);
     }
 
@@ -56,17 +71,37 @@ public class UsuarioService {
     }
 
     @Transactional
-    public Usuario atualizarUsuario(Long id, Usuario usuarioAtualizado) {
+    public Usuario atualizarUsuario(Long id, UsuarioUpdateRequest usuarioAtualizado) {
         return usuarioRepository.findById(id).map(usuario -> {
-            usuario.setNome(usuarioAtualizado.getNome());
-            usuario.setCpf(usuarioAtualizado.getCpf());
-            usuario.setDataNascimento(usuarioAtualizado.getDataNascimento());
-            usuario.setEmail(usuarioAtualizado.getEmail());
-            usuario.setEndereco(usuarioAtualizado.getEndereco());
-            usuario.setTelefone(usuarioAtualizado.getTelefone());
-            if (usuarioAtualizado.getSenha() != null && !usuarioAtualizado.getSenha().isEmpty()) {
-                usuario.setSenha(passwordEncoder.encode(usuarioAtualizado.getSenha()));
+            if (usuarioAtualizado.nome() != null && !usuarioAtualizado.nome().isBlank()) {
+                usuario.setNome(usuarioAtualizado.nome());
             }
+
+            if (usuarioAtualizado.dataNascimento() != null) {
+                usuario.setDataNascimento(usuarioAtualizado.dataNascimento());
+            }
+
+            if (usuarioAtualizado.email() != null && !usuarioAtualizado.email().isBlank()
+                    && !usuarioAtualizado.email().equalsIgnoreCase(usuario.getEmail())) {
+                if (usuarioRepository.findByEmail(usuarioAtualizado.email()).isPresent()
+                        || administradorRepository.findByEmail(usuarioAtualizado.email()).isPresent()) {
+                    throw new BadRequestException("Já existe um usuário ou administrador cadastrado com este e-mail: " + usuarioAtualizado.email());
+                }
+                usuario.setEmail(usuarioAtualizado.email());
+            }
+
+            if (usuarioAtualizado.endereco() != null && !usuarioAtualizado.endereco().isBlank()) {
+                usuario.setEndereco(usuarioAtualizado.endereco());
+            }
+
+            if (usuarioAtualizado.telefone() != null && !usuarioAtualizado.telefone().isBlank()) {
+                usuario.setTelefone(usuarioAtualizado.telefone());
+            }
+
+            if (usuarioAtualizado.senha() != null && !usuarioAtualizado.senha().isBlank()) {
+                usuario.setSenha(passwordEncoder.encode(usuarioAtualizado.senha()));
+            }
+
             return usuarioRepository.save(usuario);
         }).orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado com ID: " + id));
     }

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,7 +1,16 @@
+#PostgreSQL
 spring.datasource.url=jdbc:postgresql://localhost:5433/devdb
 spring.datasource.username=${DB_LOCAL_USER}
 spring.datasource.password=${DB_LOCAL_PASS}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
+#JWT
 jwt.secret=${JWT_SECRET_BASE64}
+
+#Bootstrap Admin
+security.bootstrap-admin.enabled=true
+security.bootstrap-admin.nome=${BOOTSTRAP_ADMIN_NOME:Admin Bootstrap}
+security.bootstrap-admin.email=${BOOTSTRAP_ADMIN_EMAIL:}
+security.bootstrap-admin.senha=${BOOTSTRAP_ADMIN_SENHA:}
+security.bootstrap-admin.telefone=${BOOTSTRAP_ADMIN_TELEFONE:}

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -9,7 +9,7 @@ spring.jpa.show-sql=true
 jwt.secret=${JWT_SECRET_BASE64}
 
 #Bootstrap Admin
-security.bootstrap-admin.enabled=true
+security.bootstrap-admin.enabled=false
 security.bootstrap-admin.nome=${BOOTSTRAP_ADMIN_NOME:Admin Bootstrap}
 security.bootstrap-admin.email=${BOOTSTRAP_ADMIN_EMAIL:}
 security.bootstrap-admin.senha=${BOOTSTRAP_ADMIN_SENHA:}

--- a/backend/src/test/java/com/vendaingressos/service/UsuarioServiceTest.java
+++ b/backend/src/test/java/com/vendaingressos/service/UsuarioServiceTest.java
@@ -1,0 +1,245 @@
+package com.vendaingressos.service;
+
+import com.vendaingressos.dto.UsuarioCreateRequest;
+import com.vendaingressos.dto.UsuarioUpdateRequest;
+import com.vendaingressos.exception.BadRequestException;
+import com.vendaingressos.exception.ResourceNotFoundException;
+import com.vendaingressos.model.Administrador;
+import com.vendaingressos.model.Compra;
+import com.vendaingressos.model.Ingresso;
+import com.vendaingressos.model.Usuario;
+import com.vendaingressos.repository.AdministradorRepository;
+import com.vendaingressos.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UsuarioServiceTest {
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    @Mock
+    private AdministradorRepository administradorRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private CompraService compraService;
+
+    @InjectMocks
+    private UsuarioService usuarioService;
+
+    private Usuario usuarioBase;
+
+    @BeforeEach
+    void setUp() {
+        usuarioBase = new Usuario();
+        usuarioBase.setIdUsuario(1L);
+        usuarioBase.setNome("Joao");
+        usuarioBase.setCpf("12345678901");
+        usuarioBase.setDataNascimento(LocalDate.of(2000, 1, 1));
+        usuarioBase.setEmail("joao@email.com");
+        usuarioBase.setSenha("senhaHash");
+        usuarioBase.setEndereco("Rua A");
+        usuarioBase.setTelefone("11999999999");
+    }
+
+    @Test
+    void cadastrarUsuario_salvaComSenhaCodificada() {
+        UsuarioCreateRequest dto = new UsuarioCreateRequest(
+                "Joao",
+                "12345678901",
+                LocalDate.of(2000, 1, 1),
+                "joao@email.com",
+                "senha123",
+                "Rua A",
+                "11999999999"
+        );
+
+        when(usuarioRepository.findByEmail(dto.email())).thenReturn(Optional.empty());
+        when(administradorRepository.findByEmail(dto.email())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(dto.senha())).thenReturn("senhaHash");
+        when(usuarioRepository.save(any(Usuario.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Usuario salvo = usuarioService.cadastrarUsuario(dto);
+
+        assertEquals("joao@email.com", salvo.getEmail());
+        assertEquals("senhaHash", salvo.getSenha());
+        verify(passwordEncoder).encode("senha123");
+        verify(usuarioRepository).save(any(Usuario.class));
+    }
+
+    @Test
+    void cadastrarUsuario_lancaQuandoEmailExisteEmUsuario() {
+        UsuarioCreateRequest dto = new UsuarioCreateRequest(
+                "Joao", "12345678901", LocalDate.of(2000, 1, 1),
+                "joao@email.com", "senha123", "Rua A", "11999999999"
+        );
+
+        when(usuarioRepository.findByEmail(dto.email())).thenReturn(Optional.of(usuarioBase));
+
+        assertThrows(BadRequestException.class, () -> usuarioService.cadastrarUsuario(dto));
+        verify(usuarioRepository, never()).save(any());
+    }
+
+    @Test
+    void cadastrarUsuario_lancaQuandoEmailExisteEmAdmin() {
+        UsuarioCreateRequest dto = new UsuarioCreateRequest(
+                "Joao", "12345678901", LocalDate.of(2000, 1, 1),
+                "joao@email.com", "senha123", "Rua A", "11999999999"
+        );
+
+        when(usuarioRepository.findByEmail(dto.email())).thenReturn(Optional.empty());
+        Administrador admin = new Administrador();
+        when(administradorRepository.findByEmail(dto.email()))
+                .thenReturn(Optional.of(admin));
+
+        assertThrows(BadRequestException.class, () -> usuarioService.cadastrarUsuario(dto));
+        verify(usuarioRepository, never()).save(any());
+    }
+
+    @Test
+    void atualizarUsuario_atualizaCamposNaoBlank() {
+        UsuarioUpdateRequest dto = new UsuarioUpdateRequest(
+                "Novo Nome",
+                LocalDate.of(1999, 12, 31),
+                "novo@email.com",
+                "novaSenha123",
+                "Rua B",
+                "11888888888"
+        );
+
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuarioBase));
+        when(usuarioRepository.findByEmail("novo@email.com")).thenReturn(Optional.empty());
+        when(administradorRepository.findByEmail("novo@email.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("novaSenha123")).thenReturn("senhaNovaHash");
+        when(usuarioRepository.save(any(Usuario.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Usuario atualizado = usuarioService.atualizarUsuario(1L, dto);
+
+        assertEquals("Novo Nome", atualizado.getNome());
+        assertEquals(LocalDate.of(1999, 12, 31), atualizado.getDataNascimento());
+        assertEquals("novo@email.com", atualizado.getEmail());
+        assertEquals("Rua B", atualizado.getEndereco());
+        assertEquals("11888888888", atualizado.getTelefone());
+        assertEquals("senhaNovaHash", atualizado.getSenha());
+    }
+
+    @Test
+    void atualizarUsuario_naoAtualizaComCamposBlank() {
+        UsuarioUpdateRequest dto = new UsuarioUpdateRequest(
+                "  ",
+                null,
+                " ",
+                "   ",
+                "",
+                " "
+        );
+
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuarioBase));
+        when(usuarioRepository.save(any(Usuario.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Usuario atualizado = usuarioService.atualizarUsuario(1L, dto);
+
+        assertEquals("Joao", atualizado.getNome());
+        assertEquals("joao@email.com", atualizado.getEmail());
+        assertEquals("Rua A", atualizado.getEndereco());
+        assertEquals("11999999999", atualizado.getTelefone());
+        assertEquals("senhaHash", atualizado.getSenha());
+    }
+
+    @Test
+    void atualizarUsuario_lancaQuandoEmailJaExiste() {
+        UsuarioUpdateRequest dto = new UsuarioUpdateRequest(
+                null, null, "existente@email.com", null, null, null
+        );
+
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuarioBase));
+        when(usuarioRepository.findByEmail("existente@email.com")).thenReturn(Optional.of(usuarioBase));
+
+        assertThrows(BadRequestException.class, () -> usuarioService.atualizarUsuario(1L, dto));
+    }
+
+    @Test
+    void atualizarUsuario_lancaQuandoUsuarioNaoExiste() {
+        UsuarioUpdateRequest dto = new UsuarioUpdateRequest(
+                "Novo", null, null, null, null, null
+        );
+
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> usuarioService.atualizarUsuario(1L, dto));
+    }
+
+    @Test
+    void deletarUsuario_lancaQuandoNaoExiste() {
+        when(usuarioRepository.existsById(1L)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> usuarioService.deletarUsuario(1L));
+        verify(usuarioRepository, never()).deleteById(anyLong());
+    }
+
+    @Test
+    void deletarUsuario_removeQuandoExiste() {
+        when(usuarioRepository.existsById(1L)).thenReturn(true);
+
+        usuarioService.deletarUsuario(1L);
+
+        verify(usuarioRepository).deleteById(1L);
+    }
+
+    @Test
+    void listarIngressosPorUsuario_lancaQuandoUsuarioNaoExiste() {
+        when(usuarioRepository.existsById(1L)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> usuarioService.listarIngressosPorUsuario(1L));
+    }
+
+    @Test
+    void listarIngressosPorUsuario_retornaIngressos() {
+        when(usuarioRepository.existsById(1L)).thenReturn(true);
+
+        Ingresso ingresso = new Ingresso();
+        Compra compra = new Compra();
+        compra.setIngresso(ingresso);
+
+        when(compraService.buscarComprasPorUsuario(1L)).thenReturn(List.of(compra));
+
+        List<Ingresso> ingressos = usuarioService.listarIngressosPorUsuario(1L);
+
+        assertEquals(1, ingressos.size());
+        assertSame(ingresso, ingressos.get(0));
+    }
+
+    @Test
+    void buscarUsuarioPorId_retornaOptional() {
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuarioBase));
+
+        Optional<Usuario> result = usuarioService.buscarUsuarioPorId(1L);
+
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    void buscarUsuarioPorEmail_retornaOptional() {
+        when(usuarioRepository.findByEmail("joao@email.com")).thenReturn(Optional.of(usuarioBase));
+
+        Optional<Usuario> result = usuarioService.buscarUsuarioPorEmail("joao@email.com");
+
+        assertTrue(result.isPresent());
+    }
+}


### PR DESCRIPTION
##  Objetivo
Este PR adiciona a estrutura completa de controle de acesso baseada nos perfis (roles) estabelecidos na issue #13, garantindo que endpoints administrativos sejam acessíveis apenas por administradores e que a documentação reflita essas permissões.

##  O que foi feito
- **Domínio:** Criação do enum `Role` (`USUARIO` e `ADMINISTRADOR`) e mapeamento nas entidades `Usuario` e `Administrador`.
- **Validações e DTOs:** Substituição da passagem direta da entidade `Usuario` com a criação do `UsuarioCreateRequest` e `UsuarioUpdateRequest` contendo as validações necessárias.
- **Autenticação:** Ajuste no `CustomUserDetailsService` para mapear e conceder as authorities reais (`ROLE_USER`, `ROLE_ADMIN`).
- **Autorização:** Atualização do `SecurityConfig` restringindo corretamente os endpoints administrativos (ex: gerência total de `/api/usuarios`, `/api/eventos`) enquanto mantém visibilidade das rotas de uso geral (ex: `/api/usuarios/me`).
- **Documentação:** Customização do Swagger via `OpenApiConfig` para exibir ícones de cadeado (`bearerAuth`) dinamicamente e mapear `x-roles` em endpoints protegidos.
- **Testes:** Adição de testes unitários via Mockito no `UsuarioService` para validar cenários de cadastro, atualização, impedimento de duplicidade de e-mail e tratamento de senha.

## Critérios de Aceite
- [x] Endpoints administrativos exigem `ROLE_ADMIN`.
- [x] Endpoints de usuário comuns operam normalmente com `ROLE_USER`.
- [x] Ajustes nos Models para não transitar Entidades nas Requisições.
- [x] Documentação reflete os níveis de acesso de cada rota.

Closes #13