### PR TITLE
fix: consistência compra–estoque e vínculo compra com múltiplos ingre…

### DIFF
--- a/backend/src/main/java/com/vendaingressos/dto/CompraResponse.java
+++ b/backend/src/main/java/com/vendaingressos/dto/CompraResponse.java
@@ -1,8 +1,13 @@
 package com.vendaingressos.dto;
 
 import com.vendaingressos.model.Compra;
+import com.vendaingressos.model.Ingresso;
 import lombok.Data;
+
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 @Data
 public class CompraResponse {
@@ -15,7 +20,10 @@ public class CompraResponse {
     private String status;
     private Long usuarioId;
     private String nomeUsuario;
+    /** Primeiro ID (menor), compatível com respostas antigas; prefira {@link #ingressoIds}. */
     private Long ingressoId;
+    /** Todos os ingressos ligados à compra (um por unidade). */
+    private List<Long> ingressoIds = List.of();
     private String nomeEvento;
 
     public CompraResponse(Compra compra) {
@@ -27,7 +35,16 @@ public class CompraResponse {
         this.status = compra.getStatus();
         this.usuarioId = compra.getUsuario().getIdUsuario();
         this.nomeUsuario = compra.getUsuario().getNome();
-        this.ingressoId = compra.getIngresso().getIdIngresso();
-        this.nomeEvento = compra.getIngresso().getSessaoEvento().getEventoPai().getNome();
+
+        List<Ingresso> lista = compra.getIngressos() != null
+                ? new ArrayList<>(compra.getIngressos())
+                : new ArrayList<>();
+        lista.sort(Comparator.comparing(Ingresso::getIdIngresso));
+        if (!lista.isEmpty()) {
+            Ingresso ref = lista.get(0);
+            this.ingressoId = ref.getIdIngresso();
+            this.nomeEvento = ref.getSessaoEvento().getEventoPai().getNome();
+            this.ingressoIds = lista.stream().map(Ingresso::getIdIngresso).toList();
+        }
     }
 }

--- a/backend/src/main/java/com/vendaingressos/dto/IngressoResponse.java
+++ b/backend/src/main/java/com/vendaingressos/dto/IngressoResponse.java
@@ -12,7 +12,11 @@ public class IngressoResponse {
 
     private Long idIngresso;
     private Double preco;
+    /** {@code false} após uso na entrada; não indica se está à venda. */
     private boolean ingressoDisponivel;
+    private boolean vendido;
+    /** Pode ser comprado ({@code !vendido}). */
+    private boolean disponivelParaCompra;
     private Long sessaoEventoId;
     private Long idTipoIngresso;
     private String nomeTipoIngresso;
@@ -21,6 +25,8 @@ public class IngressoResponse {
         this.idIngresso = ingresso.getIdIngresso();
         this.preco = ingresso.getPreco();
         this.ingressoDisponivel = ingresso.isIngressoDisponivel();
+        this.vendido = ingresso.isVendido();
+        this.disponivelParaCompra = !ingresso.isVendido();
 
         if (ingresso.getSessaoEvento() != null) {
             this.sessaoEventoId = ingresso.getSessaoEvento().getIdSessao();

--- a/backend/src/main/java/com/vendaingressos/dto/SessaoEventoResponse.java
+++ b/backend/src/main/java/com/vendaingressos/dto/SessaoEventoResponse.java
@@ -3,7 +3,6 @@ package com.vendaingressos.dto;
 import com.vendaingressos.model.SessaoEvento;
 import lombok.Data;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -13,11 +12,14 @@ public class SessaoEventoResponse {
     private String nomeSessao;
     private LocalDateTime dataHoraSessao;
     private String statusSessao;
+    /** Null significa uso da capacidade do evento pai na compra. */
+    private Integer capacidade;
 
     public SessaoEventoResponse(SessaoEvento sessaoEvento) {
         this.idSessao = sessaoEvento.getIdSessao();
         this.nomeSessao = sessaoEvento.getNomeSessao();
         this.dataHoraSessao = sessaoEvento.getDataHoraSessao();
         this.statusSessao = sessaoEvento.getStatusSessao();
+        this.capacidade = sessaoEvento.getCapacidade();
     }
 }

--- a/backend/src/main/java/com/vendaingressos/model/Compra.java
+++ b/backend/src/main/java/com/vendaingressos/model/Compra.java
@@ -1,10 +1,10 @@
 package com.vendaingressos.model;
 
 import jakarta.persistence.*;
-import lombok.*;
 
 import java.time.LocalDate;
-import java.util.UUID;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "compra")
@@ -23,22 +23,10 @@ public class Compra {
     @JoinColumn(name = "id_usuario")
     private Usuario usuario;
 
-    @ManyToOne
-    @JoinColumn(name = "id_ingresso")
-    private Ingresso ingresso;
+    @OneToMany(mappedBy = "compra", fetch = FetchType.LAZY)
+    private List<Ingresso> ingressos = new ArrayList<>();
 
     public Compra() {
-    }
-
-    public Compra(Long idCompra, LocalDate dataCompra, int quantidadeIngressos, double valorTotal, String metodoPagamento, String status, Usuario usuario, Ingresso ingresso) {
-        this.idCompra = idCompra;
-        this.dataCompra = dataCompra;
-        this.quantidadeIngressos = quantidadeIngressos;
-        this.valorTotal = valorTotal;
-        this.metodoPagamento = metodoPagamento;
-        this.status = status;
-        this.usuario = usuario;
-        this.ingresso = ingresso;
     }
 
     public Long getIdCompra() {
@@ -97,11 +85,11 @@ public class Compra {
         this.usuario = usuario;
     }
 
-    public Ingresso getIngresso() {
-        return ingresso;
+    public List<Ingresso> getIngressos() {
+        return ingressos;
     }
 
-    public void setIngresso(Ingresso ingresso) {
-        this.ingresso = ingresso;
+    public void setIngressos(List<Ingresso> ingressos) {
+        this.ingressos = ingressos;
     }
 }

--- a/backend/src/main/java/com/vendaingressos/model/Ingresso.java
+++ b/backend/src/main/java/com/vendaingressos/model/Ingresso.java
@@ -34,16 +34,24 @@ public class Ingresso {
     private TipoIngresso tipoIngresso;
 
     private boolean ingressoDisponivel = true;
+    private boolean vendido = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_compra")
+    @JsonIgnore
+    private Compra compra;
 
     public Ingresso() {
     }
 
-    public Ingresso(Long idIngresso, SessaoEvento sessaoEvento, double preco, TipoIngresso tipoIngresso, boolean ingressoDisponivel) {
+    public Ingresso(Long idIngresso, SessaoEvento sessaoEvento, double preco, TipoIngresso tipoIngresso, boolean ingressoDisponivel, boolean vendido, Compra compra) {
         this.idIngresso = idIngresso;
         this.sessaoEvento = sessaoEvento;
         this.preco = preco;
         this.tipoIngresso = tipoIngresso;
         this.ingressoDisponivel = ingressoDisponivel;
+        this.vendido = vendido;
+        this.compra = compra;
     }
 
     public Long getIdIngresso() {
@@ -84,5 +92,21 @@ public class Ingresso {
 
     public void setIngressoDisponivel(boolean ingressoDisponivel) {
         this.ingressoDisponivel = ingressoDisponivel;
+    }
+
+    public boolean isVendido() {
+        return vendido;
+    }
+
+    public void setVendido(boolean vendido) {
+        this.vendido = vendido;
+    }
+
+    public Compra getCompra() {
+        return compra;
+    }
+
+    public void setCompra(Compra compra) {
+        this.compra = compra;
     }
 }

--- a/backend/src/main/java/com/vendaingressos/model/SessaoEvento.java
+++ b/backend/src/main/java/com/vendaingressos/model/SessaoEvento.java
@@ -23,6 +23,13 @@ public class SessaoEvento {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idSessao;
 
+    /**
+     * Limite de público para esta sessão. Se null, usa-se {@link Evento#getCapacidadeTotal()}
+     * nas validações de compra.
+     */
+    @Column(name = "capacidade")
+    private Integer capacidade;
+
     @NotBlank(message = "O nome da sessão não pode estar em branco")
     @Column(nullable = false, length = 255)
     private String nomeSessao; // Ex: "Dia 1", "Sábado", "Sessão da Manhã"

--- a/backend/src/main/java/com/vendaingressos/repository/CompraRepository.java
+++ b/backend/src/main/java/com/vendaingressos/repository/CompraRepository.java
@@ -7,14 +7,24 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CompraRepository extends JpaRepository<Compra, Long> {
 
-    List<Compra> findByUsuarioIdUsuario(Long usuarioId);
-    // Alterado para buscar por ID da SessaoEvento, não mais por Evento
-    List<Compra> findByIngressoSessaoEventoIdSessao(Long sessaoEventoId);
+    @Query("SELECT DISTINCT c FROM Compra c LEFT JOIN FETCH c.ingressos WHERE c.usuario.idUsuario = :usuarioId")
+    List<Compra> findByUsuarioIdUsuarioFetchIngressos(@Param("usuarioId") Long usuarioId);
 
-    @Query("SELECT SUM(c.quantidadeIngressos) FROM Compra c WHERE c.ingresso.sessaoEvento.idSessao = :sessaoEventoId")
-    Long sumQuantidadeIngressosByIngressoSessaoEventoIdSessao(@Param("sessaoEventoId") Long sessaoEventoId);
+    @Query("SELECT DISTINCT c FROM Compra c LEFT JOIN FETCH c.ingressos")
+    List<Compra> findAllFetchIngressos();
+
+    @Query("SELECT c FROM Compra c LEFT JOIN FETCH c.ingressos WHERE c.idCompra = :id")
+    Optional<Compra> findByIdFetchIngressos(@Param("id") Long id);
+
+    @Query("SELECT DISTINCT c FROM Compra c JOIN c.ingressos i WHERE i.sessaoEvento.idSessao = :sessaoEventoId")
+    List<Compra> findDistinctByIngressosSessaoId(@Param("sessaoEventoId") Long sessaoEventoId);
+
+    @Query("SELECT COALESCE(SUM(c.quantidadeIngressos), 0) FROM Compra c WHERE c.idCompra IN "
+            + "(SELECT DISTINCT i.compra.idCompra FROM Ingresso i WHERE i.sessaoEvento.idSessao = :sessaoEventoId AND i.compra IS NOT NULL)")
+    Long sumQuantidadeIngressosByIngressosSessao(@Param("sessaoEventoId") Long sessaoEventoId);
 }

--- a/backend/src/main/java/com/vendaingressos/repository/IngressoRepository.java
+++ b/backend/src/main/java/com/vendaingressos/repository/IngressoRepository.java
@@ -1,14 +1,67 @@
 package com.vendaingressos.repository;
 
 import com.vendaingressos.model.Ingresso;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface IngressoRepository extends JpaRepository<Ingresso, Long> {
     Long countBySessaoEventoIdSessao(Long sessaoEventoId);
 
     List<Ingresso> findByTipoIngressoIdTipoIngresso(Long idTipoIngresso);
+
+    long countBySessaoEventoIdSessaoAndVendidoTrue(Long sessaoEventoId);
+
+    long countBySessaoEventoIdSessaoAndTipoIngressoIdTipoIngressoAndIngressoDisponivelTrueAndVendidoFalse(
+            Long sessaoEventoId,
+            Long tipoIngressoId
+    );
+
+    List<Ingresso> findByCompraIdCompra(Long compraId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT i FROM Ingresso i WHERE i.idIngresso = :ingressoId")
+    Optional<Ingresso> findByIdForUpdate(@Param("ingressoId") Long ingressoId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT i
+            FROM Ingresso i
+            WHERE i.sessaoEvento.idSessao = :sessaoEventoId
+              AND i.tipoIngresso.idTipoIngresso = :tipoIngressoId
+              AND i.ingressoDisponivel = true
+              AND i.vendido = false
+            ORDER BY i.idIngresso
+            """)
+    List<Ingresso> findDisponiveisParaVendaComLock(
+            @Param("sessaoEventoId") Long sessaoEventoId,
+            @Param("tipoIngressoId") Long tipoIngressoId,
+            Pageable pageable
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT i
+            FROM Ingresso i
+            WHERE i.sessaoEvento.idSessao = :sessaoEventoId
+              AND i.tipoIngresso.idTipoIngresso = :tipoIngressoId
+              AND i.ingressoDisponivel = true
+              AND i.vendido = false
+              AND i.idIngresso <> :excluirId
+            ORDER BY i.idIngresso
+            """)
+    List<Ingresso> findDisponiveisParaVendaComLockExcluindo(
+            @Param("sessaoEventoId") Long sessaoEventoId,
+            @Param("tipoIngressoId") Long tipoIngressoId,
+            @Param("excluirId") Long excluirId,
+            Pageable pageable
+    );
 }

--- a/backend/src/main/java/com/vendaingressos/repository/SessaoEventoRepository.java
+++ b/backend/src/main/java/com/vendaingressos/repository/SessaoEventoRepository.java
@@ -1,13 +1,22 @@
 package com.vendaingressos.repository;
 
 import com.vendaingressos.model.SessaoEvento;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SessaoEventoRepository extends JpaRepository<SessaoEvento, Long> {
     // Você pode adicionar métodos de consulta personalizados aqui, se necessário.
     List<SessaoEvento> findByEventoPaiId(Long eventoPaiId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM SessaoEvento s WHERE s.idSessao = :sessaoId")
+    Optional<SessaoEvento> findByIdForUpdate(@Param("sessaoId") Long sessaoId);
 }

--- a/backend/src/main/java/com/vendaingressos/repository/TipoIngressoRepository.java
+++ b/backend/src/main/java/com/vendaingressos/repository/TipoIngressoRepository.java
@@ -1,12 +1,21 @@
 package com.vendaingressos.repository;
 
 import com.vendaingressos.model.TipoIngresso;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TipoIngressoRepository extends JpaRepository<TipoIngresso, Long> {
     List<TipoIngresso> findBySessaoIdSessao(Long idSessao);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM TipoIngresso t WHERE t.idTipoIngresso = :id")
+    Optional<TipoIngresso> findByIdForUpdate(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/vendaingressos/service/CompraService.java
+++ b/backend/src/main/java/com/vendaingressos/service/CompraService.java
@@ -5,18 +5,26 @@ import com.vendaingressos.exception.BadRequestException;
 import com.vendaingressos.exception.ResourceNotFoundException;
 import com.vendaingressos.model.Compra;
 import com.vendaingressos.model.Ingresso;
+import com.vendaingressos.model.SessaoEvento;
+import com.vendaingressos.model.TipoIngresso;
 import com.vendaingressos.model.Usuario;
 import com.vendaingressos.model.enums.MetodoPagamento;
 import com.vendaingressos.repository.CompraRepository;
 import com.vendaingressos.repository.IngressoRepository;
+import com.vendaingressos.repository.SessaoEventoRepository;
+import com.vendaingressos.repository.TipoIngressoRepository;
 import com.vendaingressos.repository.UsuarioRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -25,39 +33,79 @@ public class CompraService {
     private final CompraRepository compraRepository;
     private final UsuarioRepository usuarioRepository;
     private final IngressoRepository ingressoRepository;
+    private final SessaoEventoRepository sessaoEventoRepository;
+    private final TipoIngressoRepository tipoIngressoRepository;
 
     @Autowired
-    public CompraService(CompraRepository compraRepository, UsuarioRepository usuarioRepository, IngressoRepository ingressoRepository) {
+    public CompraService(CompraRepository compraRepository,
+                         UsuarioRepository usuarioRepository,
+                         IngressoRepository ingressoRepository,
+                         SessaoEventoRepository sessaoEventoRepository,
+                         TipoIngressoRepository tipoIngressoRepository) {
         this.compraRepository = compraRepository;
         this.usuarioRepository = usuarioRepository;
         this.ingressoRepository = ingressoRepository;
+        this.sessaoEventoRepository = sessaoEventoRepository;
+        this.tipoIngressoRepository = tipoIngressoRepository;
     }
 
     @Transactional
-    public Compra realizarCompra(Long usuarioId, Long ingressoId, int quantidadeIngressos, MetodoPagamento metodoPagamento, boolean isMeiaEntrada ) {
-        Usuario usuario = usuarioRepository.findById(usuarioId)
-                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado com ID: " + usuarioId));
-        Ingresso ingresso = ingressoRepository.findById(ingressoId)
-                .orElseThrow(() -> new ResourceNotFoundException("Ingresso não encontrado com ID: " + ingressoId));
-
-        if (!ingresso.isIngressoDisponivel()) {
-            throw new BadRequestException("Ingresso não está disponível para compra.");
-        }
+    public Compra realizarCompra(Long usuarioId, Long ingressoId, int quantidadeIngressos, MetodoPagamento metodoPagamento, boolean isMeiaEntrada) {
         if (quantidadeIngressos <= 0) {
             throw new BadRequestException("A quantidade de ingressos deve ser maior que zero.");
         }
 
-        // Adicionar uma verificação mais robusta de disponibilidade baseada na capacidade da sessão
-        // e nos ingressos já vendidos para aquela sessão.
-        // A capacidade é do Evento pai, mas a contagem de vendidos é por SessaoEvento.
-        Integer capacidadeTotalEventoPorDia = ingresso.getSessaoEvento().getEventoPai().getCapacidadeTotal();
-        long ingressosVendidosNestaSessao = contarIngressosVendidosPorSessao(ingresso.getSessaoEvento().getIdSessao());
+        Usuario usuario = usuarioRepository.findById(usuarioId)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado com ID: " + usuarioId));
 
-        if ((ingressosVendidosNestaSessao + quantidadeIngressos) > capacidadeTotalEventoPorDia) {
+        Ingresso ingressoBase = ingressoRepository.findByIdForUpdate(ingressoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Ingresso não encontrado com ID: " + ingressoId));
+
+        if (!ingressoBase.isIngressoDisponivel()) {
+            throw new BadRequestException("Ingresso indisponível para compra.");
+        }
+        if (ingressoBase.isVendido()) {
+            throw new BadRequestException("O ingresso informado já foi vendido.");
+        }
+        if (ingressoBase.getTipoIngresso() == null) {
+            throw new BadRequestException("Ingresso sem tipo associado não pode ser comercializado.");
+        }
+
+        Long sessaoEventoId = ingressoBase.getSessaoEvento().getIdSessao();
+        Long tipoIngressoId = ingressoBase.getTipoIngresso().getIdTipoIngresso();
+        SessaoEvento sessaoBloqueada = sessaoEventoRepository.findByIdForUpdate(sessaoEventoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Sessão não encontrada com ID: " + sessaoEventoId));
+
+        int capacidadeMaximaSessao = resolverCapacidadeMaximaSessao(sessaoBloqueada);
+
+        long ingressosVendidosNestaSessao = contarIngressosVendidosPorSessao(sessaoEventoId);
+        if ((ingressosVendidosNestaSessao + quantidadeIngressos) > capacidadeMaximaSessao) {
             throw new BadRequestException("Não há ingressos suficientes disponíveis para esta sessão do evento.");
         }
 
-        double precoUnitarioBase = ingresso.getPreco();
+        long ingressosDisponiveisParaTipo = ingressoRepository
+                .countBySessaoEventoIdSessaoAndTipoIngressoIdTipoIngressoAndIngressoDisponivelTrueAndVendidoFalse(
+                        sessaoEventoId,
+                        tipoIngressoId
+                );
+        if (ingressosDisponiveisParaTipo < quantidadeIngressos) {
+            throw new BadRequestException("Quantidade solicitada indisponível para o tipo de ingresso selecionado.");
+        }
+
+        List<Ingresso> ingressosReservados = reservarIngressosIncluindoSemente(
+                ingressoBase,
+                sessaoEventoId,
+                tipoIngressoId,
+                quantidadeIngressos
+        );
+
+        if (ingressosReservados.size() != quantidadeIngressos) {
+            throw new BadRequestException("Não foi possível reservar a quantidade solicitada. Tente novamente.");
+        }
+
+        aplicarDecrementoTipoIngresso(tipoIngressoId, ingressosReservados.size());
+
+        double precoUnitarioBase = ingressoBase.getPreco();
 
         double precoFinalUnitario = precoUnitarioBase;
         if (isMeiaEntrada) {
@@ -69,28 +117,112 @@ public class CompraService {
             precoFinalUnitario = precoUnitarioBase / 2.0;
         }
 
-        double valorTotal = precoFinalUnitario * quantidadeIngressos;
+        double valorTotal = precoFinalUnitario * ingressosReservados.size();
 
         Compra novaCompra = new Compra();
         novaCompra.setUsuario(usuario);
-        novaCompra.setIngresso(ingresso);
         novaCompra.setDataCompra(LocalDate.now());
-        novaCompra.setQuantidadeIngressos(quantidadeIngressos);
+        novaCompra.setQuantidadeIngressos(ingressosReservados.size());
         novaCompra.setValorTotal(valorTotal);
         novaCompra.setMetodoPagamento(metodoPagamento.name());
         novaCompra.setStatus("Concluida");
 
-        return compraRepository.save(novaCompra);
+        Compra compraSalva = compraRepository.save(novaCompra);
+
+        for (Ingresso ingressoReservado : ingressosReservados) {
+            ingressoReservado.setVendido(true);
+            ingressoReservado.setCompra(compraSalva);
+        }
+        ingressoRepository.saveAll(ingressosReservados);
+
+        compraRepository.flush();
+        return compraRepository.findByIdFetchIngressos(compraSalva.getIdCompra())
+                .orElse(compraSalva);
+    }
+
+    /**
+     * Reserva exatamente {@code quantidade} ingressos, sempre incluindo o ingresso indicado pelo cliente.
+     */
+    private List<Ingresso> reservarIngressosIncluindoSemente(
+            Ingresso ingressoBase,
+            Long sessaoEventoId,
+            Long tipoIngressoId,
+            int quantidade
+    ) {
+        if (quantidade == 1) {
+            return List.of(ingressoBase);
+        }
+
+        List<Ingresso> demais = ingressoRepository.findDisponiveisParaVendaComLockExcluindo(
+                sessaoEventoId,
+                tipoIngressoId,
+                ingressoBase.getIdIngresso(),
+                PageRequest.of(0, quantidade - 1)
+        );
+        if (demais.size() != quantidade - 1) {
+            throw new BadRequestException("Não foi possível reservar a quantidade solicitada. Tente novamente.");
+        }
+
+        List<Ingresso> todos = new ArrayList<>(quantidade);
+        todos.add(ingressoBase);
+        todos.addAll(demais);
+        return todos;
+    }
+
+    private int resolverCapacidadeMaximaSessao(SessaoEvento sessao) {
+        Integer capSessao = sessao.getCapacidade();
+        if (capSessao != null && capSessao > 0) {
+            return capSessao;
+        }
+        Integer capEvento = sessao.getEventoPai().getCapacidadeTotal();
+        if (capEvento == null || capEvento <= 0) {
+            throw new BadRequestException("Capacidade da sessão inválida para realizar compra.");
+        }
+        return capEvento;
+    }
+
+    private void aplicarDecrementoTipoIngresso(Long tipoIngressoId, int quantidade) {
+        TipoIngresso tipo = tipoIngressoRepository.findByIdForUpdate(tipoIngressoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Tipo de ingresso não encontrado"));
+
+        Integer disp = tipo.getQuantidadeDisponivel();
+        if (disp != null) {
+            if (disp < quantidade) {
+                throw new BadRequestException("Quantidade solicitada indisponível para o tipo de ingresso selecionado.");
+            }
+            tipo.setQuantidadeDisponivel(disp - quantidade);
+            tipoIngressoRepository.save(tipo);
+        }
+    }
+
+    private void restaurarQuantidadeTipoIngressoPorIngressos(List<Ingresso> ingressos) {
+        Map<Long, Integer> porTipo = new HashMap<>();
+        for (Ingresso ing : ingressos) {
+            if (ing.getTipoIngresso() == null) {
+                continue;
+            }
+            Long tid = ing.getTipoIngresso().getIdTipoIngresso();
+            porTipo.merge(tid, 1, Integer::sum);
+        }
+        for (Map.Entry<Long, Integer> e : porTipo.entrySet()) {
+            TipoIngresso tipo = tipoIngressoRepository.findById(e.getKey())
+                    .orElseThrow(() -> new ResourceNotFoundException("Tipo de ingresso não encontrado"));
+            Integer disp = tipo.getQuantidadeDisponivel();
+            if (disp != null) {
+                tipo.setQuantidadeDisponivel(disp + e.getValue());
+                tipoIngressoRepository.save(tipo);
+            }
+        }
     }
 
     @Transactional(readOnly = true)
     public List<Compra> buscarTodasCompras() {
-        return compraRepository.findAll();
+        return compraRepository.findAllFetchIngressos();
     }
 
     @Transactional(readOnly = true)
     public Optional<Compra> buscarCompraPorId(Long id) {
-        return compraRepository.findById(id);
+        return compraRepository.findByIdFetchIngressos(id);
     }
 
     @Transactional(readOnly = true)
@@ -98,7 +230,7 @@ public class CompraService {
         if (!usuarioRepository.existsById(usuarioId)) {
             throw new ResourceNotFoundException("Usuário não encontrado com ID: " + usuarioId);
         }
-        return compraRepository.findByUsuarioIdUsuario(usuarioId);
+        return compraRepository.findByUsuarioIdUsuarioFetchIngressos(usuarioId);
     }
 
     @Transactional
@@ -106,25 +238,33 @@ public class CompraService {
         Compra compra = compraRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Compra não encontrada"));
 
-        // Adicione um print para depurar:
-        System.out.println("Status recebido do DTO: " + request.getStatus());
-
-        compra.setStatus(request.getStatus()); // Garanta que esta linha existe
-        return compraRepository.save(compra);
+        compra.setStatus(request.getStatus());
+        compraRepository.save(compra);
+        return compraRepository.findByIdFetchIngressos(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Compra não encontrada"));
     }
 
     @Transactional
     public void deletarCompra(Long id) {
         if (!compraRepository.existsById(id)) {
-            throw new RuntimeException("Compra não encontrada com ID: " + id);
+            throw new ResourceNotFoundException("Compra não encontrada com ID: " + id);
         }
+
+        List<Ingresso> ingressosDaCompra = ingressoRepository.findByCompraIdCompra(id);
+        restaurarQuantidadeTipoIngressoPorIngressos(ingressosDaCompra);
+
+        for (Ingresso ingresso : ingressosDaCompra) {
+            ingresso.setVendido(false);
+            ingresso.setCompra(null);
+            ingresso.setIngressoDisponivel(true);
+        }
+        ingressoRepository.saveAll(ingressosDaCompra);
+
         compraRepository.deleteById(id);
     }
 
-    // Novo método para contar ingressos vendidos por Sessão de Evento
     @Transactional(readOnly = true)
     public long contarIngressosVendidosPorSessao(Long sessaoEventoId) {
-        Long totalIngressos = compraRepository.sumQuantidadeIngressosByIngressoSessaoEventoIdSessao(sessaoEventoId);
-        return totalIngressos != null ? totalIngressos : 0;
+        return ingressoRepository.countBySessaoEventoIdSessaoAndVendidoTrue(sessaoEventoId);
     }
 }

--- a/backend/src/main/java/com/vendaingressos/service/IngressoService.java
+++ b/backend/src/main/java/com/vendaingressos/service/IngressoService.java
@@ -44,6 +44,8 @@ public class IngressoService {
         ingresso.setSessaoEvento(sessao);
         ingresso.setTipoIngresso(tipo);
         ingresso.setIngressoDisponivel(true);
+        ingresso.setVendido(false);
+        ingresso.setCompra(null);
 
         return ingressoRepository.save(ingresso);
     }
@@ -69,7 +71,7 @@ public class IngressoService {
     public boolean isIngressoValido(Long ingressoId) {
         Ingresso ingresso = ingressoRepository.findById(ingressoId)
                 .orElseThrow(() -> new ResourceNotFoundException("Ingresso não encontrado"));
-        return ingresso.isIngressoDisponivel();
+        return ingresso.isVendido() && ingresso.isIngressoDisponivel();
     }
 
     @Transactional
@@ -77,8 +79,11 @@ public class IngressoService {
         Ingresso ingresso = ingressoRepository.findById(ingressoId)
                 .orElseThrow(() -> new ResourceNotFoundException("Ingresso não encontrado"));
 
+        if (!ingresso.isVendido()) {
+            throw new BadRequestException("Ingresso ainda não foi vendido.");
+        }
         if (!ingresso.isIngressoDisponivel()) {
-            throw new BadRequestException("Ingresso já utilizado ou não disponível.");
+            throw new BadRequestException("Ingresso já utilizado.");
         }
         ingresso.setIngressoDisponivel(false);
         ingressoRepository.save(ingresso);

--- a/backend/src/main/java/com/vendaingressos/service/SessaoEventoService.java
+++ b/backend/src/main/java/com/vendaingressos/service/SessaoEventoService.java
@@ -60,6 +60,7 @@ public class SessaoEventoService {
             sessao.setNomeSessao(sessaoEventoAtualizada.getNomeSessao());
             sessao.setDataHoraSessao(sessaoEventoAtualizada.getDataHoraSessao());
             sessao.setStatusSessao(sessaoEventoAtualizada.getStatusSessao());
+            sessao.setCapacidade(sessaoEventoAtualizada.getCapacidade());
             // Se o eventoPai puder ser atualizado, adicione lógica para buscar e setar o novo eventoPai
             // Por simplicidade, assumimos que o eventoPai não muda após a criação.
 

--- a/backend/src/main/java/com/vendaingressos/service/UsuarioService.java
+++ b/backend/src/main/java/com/vendaingressos/service/UsuarioService.java
@@ -87,9 +87,8 @@ public class UsuarioService {
         // Busca todas as compras do usuário
         List<Compra> comprasDoUsuario = compraService.buscarComprasPorUsuario(usuarioId);
 
-        // Extrai os ingressos de cada compra
         return comprasDoUsuario.stream()
-                .map(Compra::getIngresso)
+                .flatMap(c -> c.getIngressos().stream())
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
# O que mudou?

Este PR alinha a **modelagem de compra** com a realidade da venda (uma compra pode incluir vários ingressos), endurece a **consistência de estoque** na sessão e por tipo de ingresso (com uso de lock pessimista onde faz sentido) e garante **reversão do estoque** ao remover uma compra. O contexto é atender os critérios da issue de correção de modelagem e consistência entre compra e estoque.

## Tarefas Relacionadas

* Issue: https://github.com/users/LuizArtur29/projects/4/views/1?pane=issue&itemId=180862197&issue=LuizArtur29%7CSistema-de-Ingressos%7C14


## Mudanças Realizadas

* **Compra ↔ ingressos:** a entidade `Compra` passa a manter relação **um-para-muitos** com `Ingresso`; na conclusão da venda, todos os ingressos reservados são marcados como vendidos e ligados à mesma compra.
* **Regras de estoque na compra:** validação de **capacidade** da sessão (com fallback para a capacidade do evento), contagem de **ingressos já vendidos** na sessão, checagem de **disponibilidade por tipo** e reserva explícita do ingresso escolhido mais os demais lugares do mesmo tipo, com **lock pessimista** em ingresso, sessão e tipo quando aplicável.
* **`TipoIngresso.quantidadeDisponivel`:** decremento na compra quando o campo está preenchido; **restauração** ao excluir a compra, junto com a liberação dos ingressos (`vendido`, `ingressoDisponivel`, vínculo com `Compra`).
* **API / DTOs:** respostas de compra (`CompraResponse` e fluxos associados) expõem **`ingressoIds`** (e mantêm `ingressoId` como referência ao primeiro id, para compatibilidade), refletindo a compra com múltiplos ingressos; ajustes correlatos em repositórios e serviços (buscas com fetch de ingressos, etc.).