### PR TITLE
fix: padroniza rotas de ingressos sob /api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,12 +30,13 @@
 /nbproject/private/
 
 # --- Infra & Env ---
-.env
+backend/.env
 .env.local
 .env.development.local
 .env.test.local
 .env.production.local
 **/.docker/
+.env
 
 # --- OS Files ---
 .DS_Store

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -105,6 +105,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>me.paulschwarz</groupId>
+			<artifactId>spring-dotenv</artifactId>
+			<version>4.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/postman/SIstema-Ingressos.postman_collection.json
+++ b/backend/postman/SIstema-Ingressos.postman_collection.json
@@ -556,16 +556,18 @@
               }
             },
             "url": {
-              "raw": "http://localhost:8080/ingressos/criar/2/6",
+              "raw": "http://localhost:8080/api/ingressos/sessoes/2/tipos/6",
               "protocol": "http",
               "host": [
                 "localhost"
               ],
               "port": "8080",
               "path": [
+                "api",
                 "ingressos",
-                "criar",
+                "sessoes",
                 "2",
+                "tipos",
                 "6"
               ]
             }
@@ -588,16 +590,17 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "http://localhost:8080/ingressos/ingressoDisponivel/3",
+              "raw": "http://localhost:8080/api/ingressos/3/disponibilidade",
               "protocol": "http",
               "host": [
                 "localhost"
               ],
               "port": "8080",
               "path": [
+                "api",
                 "ingressos",
-                "ingressoDisponivel",
-                "3"
+                "3",
+                "disponibilidade"
               ]
             }
           },
@@ -619,16 +622,17 @@
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "http://localhost:8080/ingressos/registrarEntrada/2",
+              "raw": "http://localhost:8080/api/ingressos/2/entrada",
               "protocol": "http",
               "host": [
                 "localhost"
               ],
               "port": "8080",
               "path": [
+                "api",
                 "ingressos",
-                "registrarEntrada",
-                "2"
+                "2",
+                "entrada"
               ]
             }
           },
@@ -650,15 +654,16 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "http://localhost:8080/ingressos/listarIngressosPorSessao/1",
+              "raw": "http://localhost:8080/api/ingressos/sessoes/1",
               "protocol": "http",
               "host": [
                 "localhost"
               ],
               "port": "8080",
               "path": [
+                "api",
                 "ingressos",
-                "listarIngressosPorSessao",
+                "sessoes",
                 "1"
               ]
             }
@@ -681,15 +686,15 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "http://localhost:8080/ingressos/buscarIngresso/3",
+              "raw": "http://localhost:8080/api/ingressos/3",
               "protocol": "http",
               "host": [
                 "localhost"
               ],
               "port": "8080",
               "path": [
+                "api",
                 "ingressos",
-                "buscarIngresso",
                 "3"
               ]
             }

--- a/backend/src/main/java/com/vendaingressos/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/vendaingressos/config/OpenApiConfig.java
@@ -78,11 +78,11 @@ public class OpenApiConfig {
         if (path.startsWith("/api/sessoes-evento")
                 || path.startsWith("/api/tipos-ingresso")
                 || path.startsWith("/api/administradores")
-                || path.startsWith("/ingressos")) {
+                || path.startsWith("/api/ingressos")) {
             return List.of("ROLE_ADMIN");
         }
         if (path.startsWith("/api/usuarios")) {
-            if (path.equals("/api/usuarios/me") || path.equals("/api/usuarios/meus-ingressos")) {
+            if (path.equals("/api/usuarios/me")) {
                 return List.of("ROLE_USER", "ROLE_ADMIN");
             }
             if (method != PathItem.HttpMethod.POST) {

--- a/backend/src/main/java/com/vendaingressos/config/SecurityConfig.java
+++ b/backend/src/main/java/com/vendaingressos/config/SecurityConfig.java
@@ -54,7 +54,6 @@ public class SecurityConfig {
                         //usuarios
                         .requestMatchers(HttpMethod.GET, "/api/usuarios/me").hasAnyRole("USER", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/usuarios/me").hasAnyRole("USER", "ADMIN")
-                        .requestMatchers(HttpMethod.GET, "/api/usuarios/meus-ingressos").hasAnyRole("USER", "ADMIN")
 
                         //admin
                         .requestMatchers(HttpMethod.POST, "/api/eventos/**").hasRole("ADMIN")
@@ -63,7 +62,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/sessoes-evento/**").hasRole("ADMIN")
                         .requestMatchers("/api/tipos-ingresso/**").hasRole("ADMIN")
                         .requestMatchers("/api/administradores/**").hasRole("ADMIN")
-                        .requestMatchers("/ingressos/**").hasRole("ADMIN")
+                        .requestMatchers("/api/ingressos/**").hasRole("ADMIN")
                         .requestMatchers("/api/usuarios/**").hasRole("ADMIN")
 
                         // autenticados (user/admin)

--- a/backend/src/main/java/com/vendaingressos/controller/IngressoController.java
+++ b/backend/src/main/java/com/vendaingressos/controller/IngressoController.java
@@ -2,9 +2,7 @@ package com.vendaingressos.controller;
 
 import com.vendaingressos.dto.IngressoResponse;
 import com.vendaingressos.model.Ingresso;
-import com.vendaingressos.repository.IngressoRepository;
 import com.vendaingressos.service.IngressoService;
-import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("/ingressos")
+@RequestMapping("/api/ingressos")
 public class IngressoController {
 
     private final IngressoService ingressoService;
@@ -24,20 +22,18 @@ public class IngressoController {
         this.ingressoService = ingressoService;
     }
 
-    @PostMapping("/criar/{sessaoEventoId}/{tipoIngressoId}") // Adicionamos o ID do tipo na URL
+    @PostMapping("/sessoes/{sessaoEventoId}/tipos/{tipoIngressoId}")
     public ResponseEntity<IngressoResponse> criarIngresso(
             @PathVariable Long sessaoEventoId,
-            @PathVariable Long tipoIngressoId, // Recebe o ID do tipo aqui
-            @RequestBody Ingresso ingresso) { // O corpo agora só precisa do preço
+            @PathVariable Long tipoIngressoId,
+            @RequestBody Ingresso ingresso) {
 
-        // Passamos os dois IDs para o service
         Ingresso novoIngresso = ingressoService.criarIngressoParaSessaoEvento(sessaoEventoId, tipoIngressoId, ingresso);
 
         return new ResponseEntity<>(new IngressoResponse(novoIngresso), HttpStatus.CREATED);
     }
 
-    // Alterado para listar ingressos por SessaoEvento
-    @GetMapping("listarIngressosPorSessao/{sessaoEventoId}")
+    @GetMapping("/sessoes/{sessaoEventoId}")
     public ResponseEntity<List<IngressoResponse>> listarPorSessao(@PathVariable Long sessaoEventoId) {
         List<Ingresso> ingressos = ingressoService.listarIngressosPorSessaoEvento(sessaoEventoId);
         List<IngressoResponse> ingressosDTO = ingressos.stream()
@@ -46,21 +42,20 @@ public class IngressoController {
         return new ResponseEntity<>(ingressosDTO, HttpStatus.OK);
     }
 
-    @GetMapping("buscarIngresso/{ingressoId}")
+    @GetMapping("/{ingressoId}")
     public ResponseEntity<IngressoResponse> buscarPorId(@PathVariable Long ingressoId) {
         return ingressoService.buscarIngressoPorId(ingressoId)
                 .map(ingresso -> ResponseEntity.ok(new IngressoResponse(ingresso)))
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    /* Para ser usado dentro de outro método, para servir de verificação. O controller dessa lógica apenas para teste */
-    @GetMapping("ingressoDisponivel/{ingressoId}")
+    @GetMapping("/{ingressoId}/disponibilidade")
     public ResponseEntity<Boolean> isValido(@PathVariable Long ingressoId) {
         boolean valido = ingressoService.isIngressoValido(ingressoId);
         return new  ResponseEntity<>(valido, HttpStatus.OK);
     }
 
-    @PutMapping("registrarEntrada/{ingressoId}")
+    @PutMapping("/{ingressoId}/entrada")
     public ResponseEntity<Void> registrarEntrada(@PathVariable Long ingressoId) {
         ingressoService.registrarEntrada(ingressoId);
         return new ResponseEntity<>(HttpStatus.OK);

--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -1,47 +1,111 @@
-# 🔌 Documentação da API
+# Documentacao da API
 
-Esta API segue os princípios REST e utiliza JSON como formato de intercâmbio de dados para o sistema de gerenciamento de ingressos.
+Esta API segue os principios REST e utiliza JSON como formato de intercambio de dados para o sistema de gerenciamento de ingressos.
 
----
-
-## 🚀 Documentação Interativa (Swagger)
-Para testar os endpoints em tempo real e visualizar os modelos de dados detalhados, acesse o Swagger UI com o backend em execução:
-
-🔗 **[http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)**
+Todas as rotas de negocio seguem o prefixo comum `/api`.
 
 ---
 
-## 🔐 Autenticação
-O sistema utiliza **JWT (JSON Web Token)** para proteger rotas sensíveis.
+## Documentacao Interativa (Swagger)
 
-1.  **Login:** Realize a autenticação em `/api/auth/login`.
-2.  **Token:** Capture o token retornado no corpo da resposta.
-3.  **Uso:** Envie o token em todas as requisições protegidas através do Header:
-    `Authorization: Bearer <seu_token>`
+Para testar os endpoints em tempo real e visualizar os modelos de dados detalhados, acesse o Swagger UI com o backend em execucao:
+
+`http://localhost:8080/swagger-ui.html`
+
+A especificacao OpenAPI fica disponivel em:
+
+`http://localhost:8080/v3/api-docs`
 
 ---
 
-## 📍 Endpoints Principais
+## Autenticacao
 
-### 🎫 Eventos e Sessões
-| Método | Endpoint | Descrição |
-| :--- | :--- | :--- |
-| `GET` | `/api/eventos` | Lista todos os eventos ativos. |
-| `GET` | `/api/eventos/{id}` | Retorna detalhes de um evento específico e suas sessões. |
-| `POST` | `/api/eventos` | Cadastra um novo evento (Requer privilégios de Admin). |
+O sistema utiliza JWT para proteger rotas sensiveis.
 
-### 🛒 Compras e Ingressos
-| Método | Endpoint | Descrição |
-| :--- | :--- | :--- |
-| `POST` | `/api/compras` | Processa a compra de ingressos para um usuário. |
-| `GET` | `/api/usuarios/meus-ingressos` | Lista todos os ingressos ativos do usuário autenticado. |
+1. Realize a autenticacao em `POST /api/auth/login`.
+2. Capture o token retornado no corpo da resposta.
+3. Envie o token nas rotas protegidas pelo header `Authorization: Bearer <seu_token>`.
 
-### 🔄 Transferências (P2P)
-| Método | Endpoint | Descrição |
-| :--- | :--- | :--- |
-| `POST` | `/api/transferencias` | Realiza a transferência de titularidade de um ingresso para outro usuário. |
+---
 
-**Payload (Request)**
+## Endpoints
+
+### Autenticacao
+
+| Metodo | Endpoint | Acesso | Descricao |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/api/auth/login` | Publico | Autentica usuario e retorna token JWT. |
+
+### Usuarios
+
+| Metodo | Endpoint | Acesso | Descricao |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/api/usuarios` | Publico | Cadastra um novo usuario. |
+| `GET` | `/api/usuarios` | Admin | Lista todos os usuarios. |
+| `GET` | `/api/usuarios/{id}` | Admin | Busca usuario por ID. |
+| `GET` | `/api/usuarios/email/{email}` | Admin | Busca usuario por e-mail. |
+| `PUT` | `/api/usuarios/{id}` | Admin | Atualiza usuario por ID. |
+| `DELETE` | `/api/usuarios/{id}` | Admin | Remove usuario por ID. |
+| `GET` | `/api/usuarios/me` | Usuario/Admin | Retorna o perfil do usuario autenticado. |
+| `PUT` | `/api/usuarios/me` | Usuario/Admin | Atualiza o perfil do usuario autenticado. |
+
+### Eventos
+
+| Metodo | Endpoint | Acesso | Descricao |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/api/eventos` | Publico | Lista todos os eventos. |
+| `GET` | `/api/eventos/{id}` | Publico | Retorna detalhes de um evento especifico. |
+| `POST` | `/api/eventos` | Admin | Cadastra um novo evento. |
+| `PUT` | `/api/eventos/{id}` | Admin | Atualiza um evento. |
+| `DELETE` | `/api/eventos/{id}` | Admin | Remove um evento. |
+
+### Sessoes de Evento
+
+| Metodo | Endpoint | Acesso | Descricao |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/api/sessoes-evento` | Admin | Cadastra uma sessao de evento. |
+| `GET` | `/api/sessoes-evento` | Admin | Lista todas as sessoes de evento. |
+| `GET` | `/api/sessoes-evento/{id}` | Admin | Busca sessao de evento por ID. |
+| `GET` | `/api/sessoes-evento/evento/{eventoId}` | Admin | Lista sessoes vinculadas a um evento. |
+| `PUT` | `/api/sessoes-evento/{id}` | Admin | Atualiza uma sessao de evento. |
+| `DELETE` | `/api/sessoes-evento/{id}` | Admin | Remove uma sessao de evento. |
+
+### Tipos de Ingresso
+
+| Metodo | Endpoint | Acesso | Descricao |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/api/tipos-ingresso` | Admin | Cadastra um tipo de ingresso para uma sessao. |
+| `GET` | `/api/tipos-ingresso/sessao/{sessaoId}` | Admin | Lista tipos de ingresso de uma sessao. |
+
+### Ingressos
+
+| Metodo | Endpoint | Acesso | Descricao |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/api/ingressos/sessoes/{sessaoEventoId}/tipos/{tipoIngressoId}` | Admin | Cria ingresso para uma sessao e tipo de ingresso. |
+| `GET` | `/api/ingressos/sessoes/{sessaoEventoId}` | Admin | Lista ingressos de uma sessao. |
+| `GET` | `/api/ingressos/{ingressoId}` | Admin | Busca ingresso por ID. |
+| `GET` | `/api/ingressos/{ingressoId}/disponibilidade` | Admin | Verifica se o ingresso esta disponivel. |
+| `PUT` | `/api/ingressos/{ingressoId}/entrada` | Admin | Registra entrada de um ingresso. |
+
+### Compras
+
+| Metodo | Endpoint | Acesso | Descricao |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/api/compras` | Usuario/Admin | Processa uma compra de ingresso. |
+| `GET` | `/api/compras` | Usuario/Admin | Lista todas as compras. |
+| `GET` | `/api/compras/{id}` | Usuario/Admin | Busca compra por ID. |
+| `GET` | `/api/compras/usuario/{usuarioId}` | Usuario/Admin | Lista compras de um usuario. |
+| `PUT` | `/api/compras/{id}/status` | Usuario/Admin | Atualiza status de uma compra. |
+| `DELETE` | `/api/compras/{id}` | Usuario/Admin | Remove uma compra. |
+
+### Transferencias
+
+| Metodo | Endpoint | Acesso | Descricao |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/api/transferencias` | Usuario/Admin | Realiza a transferencia de titularidade de um ingresso. |
+
+Payload:
+
 ```json
 {
   "ingressoId": 10,
@@ -49,7 +113,9 @@ O sistema utiliza **JWT (JSON Web Token)** para proteger rotas sensíveis.
   "valorRevenda": 50.0
 }
 ```
-**Resposta (Response)**
+
+Resposta:
+
 ```json
 {
   "idTransferencia": 1,
@@ -59,16 +125,33 @@ O sistema utiliza **JWT (JSON Web Token)** para proteger rotas sensíveis.
   "valorRevenda": 50.0
 }
 ```
-### Erros comuns
-- **400 Bad Request:** ingresso inválido, comprador não encontrado, valorRevenda inválido.
 
-- **403 Forbidden:** apenas o titular atual pode transferir.
+### Administradores
+
+| Metodo | Endpoint | Acesso | Descricao |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/api/administradores` | Admin | Cadastra administrador. |
+| `GET` | `/api/administradores` | Admin | Lista administradores. |
+
+---
+
+## Erros Comuns
+
+| Status | Quando ocorre |
+| :--- | :--- |
+| `400 Bad Request` | Payload invalido, campos obrigatorios ausentes ou regra de negocio violada. |
+| `401 Unauthorized` | Token ausente, invalido ou expirado. |
+| `403 Forbidden` | Usuario autenticado sem permissao para a rota. |
+| `404 Not Found` | Recurso nao encontrado. |
 
 ---
 
-## 📝 Observações Técnicas
-- **Filtros:** A listagem de eventos suporta filtros por nome, categoria e data via *Query Parameters*.
-- **Validação:** Todos os inputs são validados via Spring Validation. Erros retornam o código `400 Bad Request` com os detalhes do campo.
+## Observacoes Tecnicas
+
+- Nao ha endpoints legados fora de `/api` para recursos de negocio.
+- Rotas antigas de ingressos em `/ingressos/**` foram substituidas pelas rotas REST em `/api/ingressos/**`.
+- A documentacao interativa do Swagger deve refletir automaticamente os controllers atuais via Springdoc.
 
 ---
-**Status da API:** ![Development](https://img.shields.io/badge/Status-Em%20Desenvolvimento-yellow)
+
+**Status da API:** Em desenvolvimento.


### PR DESCRIPTION
## O que mudou?

Este PR padroniza as rotas da API sob o prefixo comum `/api`, corrigindo o controller de ingressos que ainda expunha endpoints fora do padrão. Também revisa os endpoints de ingressos para uma nomenclatura mais REST, atualiza regras de segurança, metadados do Swagger/OpenAPI, documentação e collection do Postman para refletirem as rotas reais.

## Tarefas Relacionadas

- Issue: https://github.com/users/LuizArtur29/projects/4/views/1?pane=issue&itemId=180865012&issue=LuizArtur29%7CSistema-de-Ingressos%7C18

## Mudanças Realizadas

- **IngressoController:** move a base de `/ingressos` para `/api/ingressos` e substitui endpoints verbosos por rotas REST, como `/api/ingressos/{ingressoId}`, `/api/ingressos/{ingressoId}/disponibilidade` e `/api/ingressos/{ingressoId}/entrada`.

- **Segurança:** atualiza o `SecurityConfig` para proteger `/api/ingressos/**` e remove referência à rota legada `/ingressos/**`.

- **Swagger/OpenAPI:** ajusta o `OpenApiConfig` para aplicar as roles corretas aos novos endpoints de ingressos sob `/api/ingressos`.

- **Documentação:** reescreve `docs/api_endpoints.md` com os endpoints reais dos controllers, incluindo a seção de ingressos atualizada e removendo referência a endpoint inexistente.

- **Postman:** atualiza a collection `SIstema-Ingressos.postman_collection.json` para consumir as novas rotas REST de ingressos.

## Validação

- `sh ./mvnw -DskipTests compile` executado com sucesso.

- Conferido via busca textual que os controllers principais usam `@RequestMapping("/api/...")`; apenas controller de teste permanece fora de `/api`.

- `sh ./mvnw test` ainda falha por configuração de ambiente/testes já existente, relacionada à conexão com banco e inicialização do Mockito, não às alterações de rotas.