### PR TITLE
feat(frontend): adiciona modal de confirmação para exclusões

### DIFF
--- a/frontend/app/dashboard/eventos/[id]/_components/SessionsManager.tsx
+++ b/frontend/app/dashboard/eventos/[id]/_components/SessionsManager.tsx
@@ -19,12 +19,13 @@ type SessionsManagerProps = {
     formError: string | null;
   };
   onEditSession: (sessao: SessaoEventoResponse) => void;
-  onRemoveSession: (idSessao: number) => void;
+  onRemoveSession: (sessao: SessaoEventoResponse) => void;
   onSubmitSession: (event: FormEvent) => void;
   onSessionNameChange: (value: string) => void;
   onSessionDateTimeChange: (value: string) => void;
   onSessionStatusChange: (value: SessionStatus) => void;
   onSessionCapacityChange: (value: string) => void;
+  deletingSessionId: number | null;
 };
 
 export default function SessionsManager({
@@ -40,6 +41,7 @@ export default function SessionsManager({
   onSessionDateTimeChange,
   onSessionStatusChange,
   onSessionCapacityChange,
+  deletingSessionId,
 }: SessionsManagerProps) {
   return (
     <div className={styles.section}>
@@ -67,8 +69,13 @@ export default function SessionsManager({
                   <button type="button" className={styles.btnCancel} onClick={() => onEditSession(sessao)}>
                     Editar
                   </button>
-                  <button type="button" className={styles.btnDelete} onClick={() => onRemoveSession(sessao.idSessao)}>
-                    Remover
+                  <button
+                    type="button"
+                    className={styles.btnDelete}
+                    onClick={() => onRemoveSession(sessao)}
+                    disabled={deletingSessionId !== null}
+                  >
+                    {deletingSessionId === sessao.idSessao ? "Removendo..." : "Remover"}
                   </button>
                 </div>
               )}

--- a/frontend/app/dashboard/eventos/[id]/_hooks/useEventDetailsController.ts
+++ b/frontend/app/dashboard/eventos/[id]/_hooks/useEventDetailsController.ts
@@ -32,6 +32,17 @@ import { useEventDetails } from "./useEventDetails";
 import { useEventSessions } from "./useEventSessions";
 import { useTicketTypes } from "./useTicketTypes";
 
+type DeleteTarget =
+  | {
+      type: "event";
+      name: string;
+    }
+  | {
+      type: "session";
+      id: number;
+      name: string;
+    };
+
 export function useEventDetailsController(eventId: number, isAdmin: boolean) {
   const router = useRouter();
   const { showToast } = useToast();
@@ -49,6 +60,8 @@ export function useEventDetailsController(eventId: number, isAdmin: boolean) {
   const { form, setForm, setError } = eventDetails;
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [deletingSessionId, setDeletingSessionId] = useState<number | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
   const [fieldErrors, setFieldErrors] = useState<EventFieldErrors>({});
 
   const [sessaoNome, setSessaoNome] = useState("");
@@ -129,7 +142,7 @@ export function useEventDetailsController(eventId: number, isAdmin: boolean) {
     }
   };
 
-  const handleDelete = async () => {
+  const handleDelete = () => {
     if (!isAdmin) {
       const message = getForbiddenMessage();
       setError(message);
@@ -137,25 +150,59 @@ export function useEventDetailsController(eventId: number, isAdmin: boolean) {
       return;
     }
 
-    const confirmed = window.confirm(
-      "Tem certeza que deseja excluir este evento? Essa ação não pode ser desfeita."
-    );
+    setDeleteTarget({ type: "event", name: form.nome || "Evento sem nome" });
+  };
 
-    if (!confirmed) return;
+  const closeDeleteDialog = () => {
+    if (deleting || deletingSessionId !== null) return;
+    setDeleteTarget(null);
+  };
 
-    setError(null);
-    setDeleting(true);
+  const confirmDelete = async () => {
+    if (!deleteTarget || deleting || deletingSessionId !== null) return;
+
+    if (!isAdmin) {
+      const message = getForbiddenMessage();
+      setError(message);
+      showToast(message, "error");
+      return;
+    }
+
+    if (deleteTarget.type === "event") {
+      setError(null);
+      setDeleting(true);
+
+      try {
+        await excluirEvento(eventId);
+        showToast("Evento excluído com sucesso.", "success");
+        setDeleteTarget(null);
+        router.push("/dashboard");
+      } catch (err: unknown) {
+        const message = isForbiddenError(err) ? getForbiddenMessage() : "Não foi possível excluir o evento.";
+        setError(message);
+        showToast(isForbiddenError(err) ? message : "Falha ao excluir evento.", "error");
+      } finally {
+        setDeleting(false);
+      }
+
+      return;
+    }
+
+    setDeletingSessionId(deleteTarget.id);
+    let deletedSession = false;
 
     try {
-      await excluirEvento(eventId);
-      showToast("Evento excluído com sucesso.", "success");
-      router.push("/dashboard");
+      await excluirSessao(deleteTarget.id);
+      showToast("Sessão removida.", "success");
+      await sessions.reloadSessoes();
+      deletedSession = true;
     } catch (err: unknown) {
-      const message = isForbiddenError(err) ? getForbiddenMessage() : "Não foi possível excluir o evento.";
-      setError(message);
-      showToast(isForbiddenError(err) ? message : "Falha ao excluir evento.", "error");
+      showToast(isForbiddenError(err) ? getForbiddenMessage() : "Erro ao remover sessão.", "error");
     } finally {
-      setDeleting(false);
+      setDeletingSessionId(null);
+      if (deletedSession) {
+        setDeleteTarget(null);
+      }
     }
   };
 
@@ -236,22 +283,17 @@ export function useEventDetailsController(eventId: number, isAdmin: boolean) {
     }
   };
 
-  const handleRemoverSessao = async (idSessao: number) => {
+  const handleRemoverSessao = (sessao: SessaoEventoResponse) => {
     if (!isAdmin) {
       showToast(getForbiddenMessage(), "error");
       return;
     }
 
-    const confirmed = window.confirm("Deseja remover esta sessão?");
-    if (!confirmed) return;
-
-    try {
-      await excluirSessao(idSessao);
-      showToast("Sessão removida.", "success");
-      await sessions.reloadSessoes();
-    } catch (err: unknown) {
-      showToast(isForbiddenError(err) ? getForbiddenMessage() : "Erro ao remover sessão.", "error");
-    }
+    setDeleteTarget({
+      type: "session",
+      id: sessao.idSessao,
+      name: sessao.nomeSessao || `Sessão ${sessao.idSessao}`,
+    });
   };
 
   const handleCriarTipo = async (event: FormEvent) => {
@@ -316,7 +358,15 @@ export function useEventDetailsController(eventId: number, isAdmin: boolean) {
     ticketTypes,
     saving,
     deleting,
+    deletingSessionId,
     fieldErrors,
+    deleteDialog: {
+      target: deleteTarget,
+      isOpen: deleteTarget !== null,
+      isLoading: deleting || deletingSessionId !== null,
+      close: closeDeleteDialog,
+      confirm: confirmDelete,
+    },
     eventHandlers: {
       updateField,
       handleSave,

--- a/frontend/app/dashboard/eventos/[id]/page.tsx
+++ b/frontend/app/dashboard/eventos/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import ConfirmDialog from "@/components/ConfirmDialog";
 import { usePermissions } from "@/hooks/useAuthUser";
 import EventForm from "./_components/EventForm";
 import SessionsManager from "./_components/SessionsManager";
@@ -95,6 +96,7 @@ export default function EventDetails() {
         onSessionDateTimeChange={controller.sessionHandlers.setDataHora}
         onSessionStatusChange={controller.sessionHandlers.setStatus}
         onSessionCapacityChange={controller.sessionHandlers.setCapacidade}
+        deletingSessionId={controller.deletingSessionId}
       />
 
       <TicketTypesManager
@@ -111,6 +113,26 @@ export default function EventDetails() {
         onPriceChange={controller.ticketTypeHandlers.setPreco}
         onQuantityChange={controller.ticketTypeHandlers.setQuantidadeTotal}
         onLotChange={controller.ticketTypeHandlers.setLote}
+      />
+
+      <ConfirmDialog
+        open={controller.deleteDialog.isOpen}
+        title={
+          controller.deleteDialog.target?.type === "session"
+            ? "Remover sessão?"
+            : "Excluir evento?"
+        }
+        description={
+          controller.deleteDialog.target?.type === "session"
+            ? "Esta sessão será removida do evento. Essa ação não pode ser desfeita."
+            : "Este evento será excluído permanentemente. Essa ação não pode ser desfeita."
+        }
+        resourceName={controller.deleteDialog.target?.name ?? ""}
+        confirmLabel={controller.deleteDialog.target?.type === "session" ? "Remover sessão" : "Excluir evento"}
+        loadingLabel={controller.deleteDialog.target?.type === "session" ? "Removendo..." : "Excluindo..."}
+        isLoading={controller.deleteDialog.isLoading}
+        onCancel={controller.deleteDialog.close}
+        onConfirm={controller.deleteDialog.confirm}
       />
     </div>
   );

--- a/frontend/components/ConfirmDialog.tsx
+++ b/frontend/components/ConfirmDialog.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { KeyboardEvent, ReactNode, useEffect, useId, useRef } from "react";
+import styles from "./confirm-dialog.module.css";
+
+type ConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  description: ReactNode;
+  resourceName: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  loadingLabel?: string;
+  isLoading?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+const FOCUSABLE_SELECTOR = [
+  "button:not(:disabled)",
+  "[href]",
+  "input:not(:disabled)",
+  "select:not(:disabled)",
+  "textarea:not(:disabled)",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  resourceName,
+  confirmLabel = "Confirmar",
+  cancelLabel = "Cancelar",
+  loadingLabel = "Excluindo...",
+  isLoading = false,
+  onCancel,
+  onConfirm,
+}: ConfirmDialogProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    previousFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const frame = window.requestAnimationFrame(() => {
+      cancelButtonRef.current?.focus();
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape" && !isLoading) {
+      event.preventDefault();
+      onCancel();
+      return;
+    }
+
+    if (event.key !== "Tab") return;
+
+    const focusableElements = Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? []
+    ).filter((element) => element.offsetParent !== null);
+
+    if (focusableElements.length === 0) {
+      event.preventDefault();
+      dialogRef.current?.focus();
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement.focus();
+    } else if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus();
+    }
+  };
+
+  return (
+    <div className={styles.backdrop}>
+      <div
+        ref={dialogRef}
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        aria-busy={isLoading}
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+      >
+        <div className={styles.warningIcon} aria-hidden="true">
+          !
+        </div>
+
+        <div className={styles.content}>
+          <h2 id={titleId} className={styles.title}>
+            {title}
+          </h2>
+          <div id={descriptionId} className={styles.description}>
+            <p>{description}</p>
+            <p className={styles.resourceName}>{resourceName}</p>
+          </div>
+        </div>
+
+        <div className={styles.actions}>
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            className={styles.cancelButton}
+            onClick={onCancel}
+            disabled={isLoading}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className={styles.confirmButton}
+            onClick={onConfirm}
+            disabled={isLoading}
+          >
+            {isLoading ? loadingLabel : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/confirm-dialog.module.css
+++ b/frontend/components/confirm-dialog.module.css
@@ -1,0 +1,122 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(17, 24, 39, 0.5);
+}
+
+.dialog {
+  width: min(100%, 420px);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--card-bg);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.24);
+  padding: 1.5rem;
+  outline: none;
+}
+
+.warningIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-bottom: 1rem;
+  border-radius: 999px;
+  background: var(--danger-bg);
+  color: var(--danger-text);
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.title {
+  color: var(--text-main);
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.description {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.resourceName {
+  margin-top: 0.75rem;
+  border-left: 3px solid var(--danger-text);
+  background: var(--danger-bg);
+  color: var(--danger-text);
+  font-weight: 600;
+  padding: 0.75rem;
+  overflow-wrap: anywhere;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.cancelButton,
+.confirmButton {
+  min-width: 8rem;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: background-color 0.2s, border-color 0.2s, opacity 0.2s;
+}
+
+.cancelButton {
+  border: 1px solid var(--border-color);
+  background: white;
+  color: var(--text-main);
+}
+
+.cancelButton:hover:not(:disabled) {
+  background: var(--neutral-bg);
+}
+
+.confirmButton {
+  border: 1px solid var(--danger-text);
+  background: var(--danger-text);
+  color: white;
+}
+
+.confirmButton:hover:not(:disabled) {
+  background: #b91c1c;
+  border-color: #b91c1c;
+}
+
+.cancelButton:disabled,
+.confirmButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+@media (max-width: 520px) {
+  .backdrop {
+    align-items: flex-end;
+    padding: 1rem;
+  }
+
+  .actions {
+    flex-direction: column-reverse;
+  }
+
+  .cancelButton,
+  .confirmButton {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Cria ConfirmDialog reutilizável e substitui window.confirm nas exclusões de evento e sessão. O modal exibe o recurso afetado, trata foco/teclado, desabilita ações durante loading e destaca visualmente a ação destrutiva.