### PR TITLE
refactor(frontend): centraliza componentes base de formulário

### DIFF
--- a/frontend/app/dashboard/create/page.module.css
+++ b/frontend/app/dashboard/create/page.module.css
@@ -38,14 +38,6 @@
   font-size: 1rem;
 }
 
-.formCard {
-  background: white;
-  border-radius: 12px;
-  border: 1px solid var(--border-color);
-  padding: 2.5rem;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
-}
-
 .section {
   margin-bottom: 2.5rem;
 }
@@ -59,10 +51,6 @@
   border-bottom: 1px solid var(--border-color);
 }
 
-.formGroup {
-  margin-bottom: 1.5rem;
-}
-
 .row {
   display: flex;
   gap: 1.5rem;
@@ -73,134 +61,15 @@
   flex: 1;
 }
 
-.label {
-  display: block;
-  font-size: 0.95rem;
-  color: var(--text-main);
-  margin-bottom: 0.5rem;
-}
-
-.required {
-  color: var(--danger-text);
-}
-
-.input, .textarea, .select {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  font-size: 0.95rem;
-  outline: none;
-  transition: all 0.2s ease;
-  color: var(--text-main);
-  background-color: white;
-}
-
-.textarea {
-  resize: vertical;
-  min-height: 120px;
-}
-
-.input::placeholder, .textarea::placeholder {
-  color: #9ca3af;
-}
-
-.input:focus, .textarea:focus, .select:focus {
-  border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px rgba(26, 92, 255, 0.1);
-}
-
 .errorText {
   color: var(--danger-text);
   font-size: 0.9rem;
   margin-top: 0.5rem;
 }
 
-.inputIcon {
-  position: relative;
-}
-
-.inputIcon input {
-  padding-right: 2.5rem;
-}
-
-.iconRight {
-  position: absolute;
-  right: 1rem;
-  top: 50%;
-  transform: translateY(-50%);
-  color: #9ca3af;
-  pointer-events: none;
-}
-
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 1rem;
-  margin-top: 3rem;
-}
-
-.btnCancel {
-  padding: 0.75rem 1.5rem;
-  background-color: white;
-  border: 1px solid var(--border-color);
-  color: var(--text-main);
-  border-radius: 8px;
-  font-weight: 500;
-  font-size: 0.95rem;
-  transition: background-color 0.2s;
-}
-
-.btnCancel:hover {
-  background-color: var(--neutral-bg);
-}
-
-.btnSave {
-  padding: 0.75rem 1.5rem;
-  background-color: var(--primary-blue);
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-weight: 500;
-  font-size: 0.95rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  transition: background-color 0.2s;
-}
-
-.btnSave:hover {
-  background-color: var(--primary-hover);
-}
-
-.btnCancel:disabled,
-.btnSave:disabled {
-  cursor: not-allowed;
-  opacity: 0.65;
-}
-
-.btnSave:disabled:hover {
-  background-color: var(--primary-blue);
-}
-
 @media (max-width: 640px) {
-  .formCard {
-    padding: 1.5rem;
-  }
-
   .row {
     flex-direction: column;
     gap: 1rem;
-  }
-
-  .actions {
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-
-  .btnCancel,
-  .btnSave {
-    width: 100%;
-    justify-content: center;
   }
 }

--- a/frontend/app/dashboard/create/page.tsx
+++ b/frontend/app/dashboard/create/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { isAxiosError } from "axios";
 import AdminGuard from "@/components/AdminGuard";
 import { useToast } from "@/components/ToastProvider";
+import { Button, Card, FormActions, SelectField, TextareaField, TextField } from "@/components/ui";
 import { getForbiddenMessage, isForbiddenError } from "@/lib/apiErrors";
 import { criarEvento } from "@/services/eventos";
 import { ApiProblemDetail, EventoCreateRequest, EventoStatus } from "@/services/types";
@@ -118,39 +119,31 @@ export default function CreateEvent() {
           <p className={styles.subtitle}>Preencha os campos abaixo para cadastrar um novo evento.</p>
         </div>
 
-        <div className={styles.formCard}>
+        <Card>
           <form onSubmit={handleSave} noValidate>
             <div className={styles.section}>
               <h2 className={styles.sectionTitle}>Informações Básicas</h2>
 
-              <div className={styles.formGroup}>
-                <label className={styles.label}>
-                  Nome do evento <span className={styles.required}>*</span>
-                </label>
-                <input
-                    type="text"
-                    className={styles.input}
-                    placeholder="Ex.: Festival de Música 2026"
-                    value={form.nome}
-                    onChange={(e) => updateField("nome", e.target.value)}
-                    required
-                />
-                {fieldErrors.nome && <p className={styles.errorText}>{fieldErrors.nome}</p>}
-              </div>
+              <TextField
+                id="create-event-name"
+                label="Nome do evento"
+                type="text"
+                placeholder="Ex.: Festival de Música 2026"
+                value={form.nome}
+                onChange={(e) => updateField("nome", e.target.value)}
+                required
+                error={fieldErrors.nome}
+              />
 
-              <div className={styles.formGroup}>
-                <label className={styles.label}>
-                  Descrição <span className={styles.required}>*</span>
-                </label>
-                <textarea
-                    className={styles.textarea}
-                    placeholder="Descreva o evento, atrações, programação..."
-                    value={form.descricao}
-                    onChange={(e) => updateField("descricao", e.target.value)}
-                    required
-                />
-                {fieldErrors.descricao && <p className={styles.errorText}>{fieldErrors.descricao}</p>}
-              </div>
+              <TextareaField
+                id="create-event-description"
+                label="Descrição"
+                placeholder="Descreva o evento, atrações, programação..."
+                value={form.descricao}
+                onChange={(e) => updateField("descricao", e.target.value)}
+                required
+                error={fieldErrors.descricao}
+              />
             </div>
 
             <div className={styles.section}>
@@ -158,51 +151,39 @@ export default function CreateEvent() {
 
               <div className={styles.row}>
                 <div className={styles.col}>
-                  <label className={styles.label}>
-                    Data de início <span className={styles.required}>*</span>
-                  </label>
-                  <div className={styles.inputIcon}>
-                    <input
-                        type="date"
-                        className={styles.input}
-                        value={form.dataInicio}
-                        onChange={(e) => updateField("dataInicio", e.target.value)}
-                        required
-                    />
-                  </div>
-                  {fieldErrors.dataInicio && <p className={styles.errorText}>{fieldErrors.dataInicio}</p>}
+                  <TextField
+                    id="create-event-start-date"
+                    label="Data de início"
+                    type="date"
+                    value={form.dataInicio}
+                    onChange={(e) => updateField("dataInicio", e.target.value)}
+                    required
+                    error={fieldErrors.dataInicio}
+                  />
                 </div>
                 <div className={styles.col}>
-                  <label className={styles.label}>
-                    Data de término <span className={styles.required}>*</span>
-                  </label>
-                  <div className={styles.inputIcon}>
-                    <input
-                        type="date"
-                        className={styles.input}
-                        value={form.dataFim}
-                        onChange={(e) => updateField("dataFim", e.target.value)}
-                        required
-                    />
-                  </div>
-                  {fieldErrors.dataFim && <p className={styles.errorText}>{fieldErrors.dataFim}</p>}
+                  <TextField
+                    id="create-event-end-date"
+                    label="Data de término"
+                    type="date"
+                    value={form.dataFim}
+                    onChange={(e) => updateField("dataFim", e.target.value)}
+                    required
+                    error={fieldErrors.dataFim}
+                  />
                 </div>
               </div>
 
-              <div className={styles.formGroup}>
-                <label className={styles.label}>
-                  Local <span className={styles.required}>*</span>
-                </label>
-                <input
-                  type="text"
-                  className={styles.input}
-                  placeholder="Ex.: Parque Ibirapuera, São Paulo - SP"
-                  value={form.local}
-                  onChange={(e) => updateField("local", e.target.value)}
-                  required
-                />
-                {fieldErrors.local && <p className={styles.errorText}>{fieldErrors.local}</p>}
-              </div>
+              <TextField
+                id="create-event-location"
+                label="Local"
+                type="text"
+                placeholder="Ex.: Parque Ibirapuera, São Paulo - SP"
+                value={form.local}
+                onChange={(e) => updateField("local", e.target.value)}
+                required
+                error={fieldErrors.local}
+              />
             </div>
 
             <div className={styles.section}>
@@ -210,59 +191,53 @@ export default function CreateEvent() {
 
               <div className={styles.row}>
                 <div className={styles.col}>
-                  <label className={styles.label}>
-                    Capacidade total <span className={styles.required}>*</span>
-                  </label>
-                  <input
-                      type="number"
-                      className={styles.input}
-                      placeholder="Ex.: 500"
-                      value={form.capacidadeTotal}
-                      onChange={(e) => updateField("capacidadeTotal", e.target.value)}
-                      min="1"
-                      step="1"
-                      required
+                  <TextField
+                    id="create-event-capacity"
+                    label="Capacidade total"
+                    type="number"
+                    placeholder="Ex.: 500"
+                    value={form.capacidadeTotal}
+                    onChange={(e) => updateField("capacidadeTotal", e.target.value)}
+                    min="1"
+                    step="1"
+                    required
+                    error={fieldErrors.capacidadeTotal}
                   />
-                  {fieldErrors.capacidadeTotal && (
-                    <p className={styles.errorText}>{fieldErrors.capacidadeTotal}</p>
-                  )}
                 </div>
                 <div className={styles.col}>
-                  <label className={styles.label}>
-                    Status <span className={styles.required}>*</span>
-                  </label>
-                  <select
-                      className={styles.select}
-                      value={form.status}
-                      onChange={(e) => updateField("status", e.target.value as EventoStatus)}
-                      required
+                  <SelectField
+                    id="create-event-status"
+                    label="Status"
+                    value={form.status}
+                    onChange={(e) => updateField("status", e.target.value as EventoStatus)}
+                    required
+                    error={fieldErrors.status}
                   >
                     <option value="ATIVO">Ativo</option>
                     <option value="CANCELADO">Cancelado</option>
                     <option value="FINALIZADO">Finalizado</option>
-                  </select>
-                  {fieldErrors.status && <p className={styles.errorText}>{fieldErrors.status}</p>}
+                  </SelectField>
                 </div>
               </div>
             </div>
 
             {error && <p className={styles.errorText}>{error}</p>}
 
-            <div className={styles.actions}>
-              <button
-                  type="button"
-                  className={styles.btnCancel}
-                  onClick={() => router.push("/dashboard")}
-                  disabled={loading}
+            <FormActions>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => router.push("/dashboard")}
+                disabled={loading}
               >
                 Cancelar
-              </button>
-              <button type="submit" className={styles.btnSave} disabled={loading}>
+              </Button>
+              <Button type="submit" disabled={loading}>
                 {loading ? "Salvando..." : "Salvar Evento"}
-              </button>
-            </div>
+              </Button>
+            </FormActions>
           </form>
-        </div>
+        </Card>
       </div>
     </AdminGuard>
   );

--- a/frontend/app/dashboard/eventos/[id]/_components/EventForm.tsx
+++ b/frontend/app/dashboard/eventos/[id]/_components/EventForm.tsx
@@ -1,4 +1,5 @@
 import { FormEvent } from "react";
+import { Button, Card, FormActions, SelectField, TextareaField, TextField } from "@/components/ui";
 import { EventoStatus } from "@/services/types";
 import { EventFieldErrors, EventFormState } from "../_utils/eventDetailsTypes";
 import styles from "../page.module.css";
@@ -27,43 +28,33 @@ export default function EventForm({
   onFieldChange,
 }: EventFormProps) {
   return (
-    <div className={styles.formCard}>
+    <Card>
       <form onSubmit={onSubmit} noValidate aria-describedby={error ? "event-form-error" : undefined}>
         <div className={styles.section}>
           <h2 className={styles.sectionTitle}>Informações Básicas</h2>
 
-          <div className={styles.formGroup}>
-            <label className={styles.label} htmlFor="event-name">
-              Nome do evento <span className={styles.required}>*</span>
-            </label>
-            <input
-              id="event-name"
-              type="text"
-              className={styles.input}
-              placeholder="Ex.: Festival de Música 2026"
-              value={form.nome}
-              onChange={(e) => onFieldChange("nome", e.target.value)}
-              disabled={!isAdmin}
-              required
-            />
-            {fieldErrors.nome && <p className={styles.errorText}>{fieldErrors.nome}</p>}
-          </div>
+          <TextField
+            id="event-name"
+            label="Nome do evento"
+            type="text"
+            placeholder="Ex.: Festival de Música 2026"
+            value={form.nome}
+            onChange={(e) => onFieldChange("nome", e.target.value)}
+            disabled={!isAdmin}
+            required
+            error={fieldErrors.nome}
+          />
 
-          <div className={styles.formGroup}>
-            <label className={styles.label} htmlFor="event-description">
-              Descrição <span className={styles.required}>*</span>
-            </label>
-            <textarea
-              id="event-description"
-              className={styles.textarea}
-              placeholder="Descreva o evento, atrações, programação..."
-              value={form.descricao}
-              onChange={(e) => onFieldChange("descricao", e.target.value)}
-              disabled={!isAdmin}
-              required
-            />
-            {fieldErrors.descricao && <p className={styles.errorText}>{fieldErrors.descricao}</p>}
-          </div>
+          <TextareaField
+            id="event-description"
+            label="Descrição"
+            placeholder="Descreva o evento, atrações, programação..."
+            value={form.descricao}
+            onChange={(e) => onFieldChange("descricao", e.target.value)}
+            disabled={!isAdmin}
+            required
+            error={fieldErrors.descricao}
+          />
         </div>
 
         <div className={styles.section}>
@@ -71,53 +62,42 @@ export default function EventForm({
 
           <div className={styles.row}>
             <div className={styles.col}>
-              <label className={styles.label} htmlFor="event-start-date">
-                Data de início <span className={styles.required}>*</span>
-              </label>
-              <input
+              <TextField
                 id="event-start-date"
+                label="Data de início"
                 type="date"
-                className={styles.input}
                 value={form.dataInicio}
                 onChange={(e) => onFieldChange("dataInicio", e.target.value)}
                 disabled={!isAdmin}
                 required
+                error={fieldErrors.dataInicio}
               />
-              {fieldErrors.dataInicio && <p className={styles.errorText}>{fieldErrors.dataInicio}</p>}
             </div>
             <div className={styles.col}>
-              <label className={styles.label} htmlFor="event-end-date">
-                Data de término <span className={styles.required}>*</span>
-              </label>
-              <input
+              <TextField
                 id="event-end-date"
+                label="Data de término"
                 type="date"
-                className={styles.input}
                 value={form.dataFim}
                 onChange={(e) => onFieldChange("dataFim", e.target.value)}
                 disabled={!isAdmin}
                 required
+                error={fieldErrors.dataFim}
               />
-              {fieldErrors.dataFim && <p className={styles.errorText}>{fieldErrors.dataFim}</p>}
             </div>
           </div>
 
-          <div className={styles.formGroup}>
-            <label className={styles.label} htmlFor="event-location">
-              Local <span className={styles.required}>*</span>
-            </label>
-            <input
-              id="event-location"
-              type="text"
-              className={styles.input}
-              placeholder="Ex.: Parque Ibirapuera, São Paulo - SP"
-              value={form.local}
-              onChange={(e) => onFieldChange("local", e.target.value)}
-              disabled={!isAdmin}
-              required
-            />
-            {fieldErrors.local && <p className={styles.errorText}>{fieldErrors.local}</p>}
-          </div>
+          <TextField
+            id="event-location"
+            label="Local"
+            type="text"
+            placeholder="Ex.: Parque Ibirapuera, São Paulo - SP"
+            value={form.local}
+            onChange={(e) => onFieldChange("local", e.target.value)}
+            disabled={!isAdmin}
+            required
+            error={fieldErrors.local}
+          />
         </div>
 
         <div className={styles.section}>
@@ -125,59 +105,51 @@ export default function EventForm({
 
           <div className={styles.row}>
             <div className={styles.col}>
-              <label className={styles.label} htmlFor="event-capacity">
-                Capacidade total <span className={styles.required}>*</span>
-              </label>
-              <input
+              <TextField
                 id="event-capacity"
+                label="Capacidade total"
                 type="number"
                 min="1"
                 step="1"
-                className={styles.input}
                 placeholder="Ex.: 500"
                 value={form.capacidadeTotal}
                 onChange={(e) => onFieldChange("capacidadeTotal", e.target.value)}
                 disabled={!isAdmin}
                 required
+                error={fieldErrors.capacidadeTotal}
               />
-              {fieldErrors.capacidadeTotal && (
-                <p className={styles.errorText}>{fieldErrors.capacidadeTotal}</p>
-              )}
             </div>
             <div className={styles.col}>
-              <label className={styles.label} htmlFor="event-status">
-                Status <span className={styles.required}>*</span>
-              </label>
-              <select
+              <SelectField
                 id="event-status"
-                className={styles.select}
+                label="Status"
                 value={form.status}
                 onChange={(e) => onFieldChange("status", e.target.value as EventoStatus)}
                 disabled={!isAdmin}
                 required
+                error={fieldErrors.status}
               >
                 <option value="ATIVO">Ativo</option>
                 <option value="CANCELADO">Cancelado</option>
                 <option value="FINALIZADO">Finalizado</option>
-              </select>
-              {fieldErrors.status && <p className={styles.errorText}>{fieldErrors.status}</p>}
+              </SelectField>
             </div>
           </div>
         </div>
 
         {error && <p id="event-form-error" className={styles.errorText}>{error}</p>}
 
-        <div className={styles.actions}>
-          <button type="button" className={styles.btnCancel} onClick={onCancel} disabled={saving || deleting}>
+        <FormActions>
+          <Button type="button" variant="secondary" onClick={onCancel} disabled={saving || deleting}>
             Cancelar
-          </button>
+          </Button>
           {isAdmin && (
-            <button type="submit" className={styles.btnSave} disabled={saving || deleting}>
+            <Button type="submit" disabled={saving || deleting}>
               {saving ? "Salvando..." : "Salvar Alterações"}
-            </button>
+            </Button>
           )}
-        </div>
+        </FormActions>
       </form>
-    </div>
+    </Card>
   );
 }

--- a/frontend/app/dashboard/eventos/[id]/_components/SessionsManager.tsx
+++ b/frontend/app/dashboard/eventos/[id]/_components/SessionsManager.tsx
@@ -1,4 +1,5 @@
 import { FormEvent } from "react";
+import { Button, Card, SelectField, TextField } from "@/components/ui";
 import { SessaoEventoResponse } from "@/services/types";
 import { toDateTimeLocal } from "../_utils/dateHelpers";
 import { SESSION_STATUS_OPTIONS, SessionFieldErrors, SessionStatus } from "../_utils/eventDetailsTypes";
@@ -66,17 +67,17 @@ export default function SessionsManager({
               </div>
               {isAdmin && (
                 <div className={styles.actionsInline}>
-                  <button type="button" className={styles.btnCancel} onClick={() => onEditSession(sessao)}>
+                  <Button type="button" variant="secondary" onClick={() => onEditSession(sessao)}>
                     Editar
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     type="button"
-                    className={styles.btnDelete}
+                    variant="danger"
                     onClick={() => onRemoveSession(sessao)}
                     disabled={deletingSessionId !== null}
                   >
                     {deletingSessionId === sessao.idSessao ? "Removendo..." : "Remover"}
-                  </button>
+                  </Button>
                 </div>
               )}
             </div>
@@ -85,71 +86,63 @@ export default function SessionsManager({
       )}
 
       {isAdmin && (
-        <form onSubmit={onSubmitSession} className={styles.formCard} noValidate>
-          <h3>{form.editando ? "Editar Sessão" : "Nova Sessão"}</h3>
+        <Card className={styles.inlineFormCard}>
+          <form onSubmit={onSubmitSession} noValidate>
+            <h3>{form.editando ? "Editar Sessão" : "Nova Sessão"}</h3>
 
-          <label className={styles.label} htmlFor="session-name">
-            Nome da sessão <span className={styles.required}>*</span>
-          </label>
-          <input
-            id="session-name"
-            type="text"
-            className={styles.input}
-            placeholder="Nome da sessão"
-            value={form.nome}
-            onChange={(e) => onSessionNameChange(e.target.value)}
-            required
-          />
-          {form.fieldErrors.nomeSessao && <p className={styles.errorText}>{form.fieldErrors.nomeSessao}</p>}
+            <TextField
+              id="session-name"
+              label="Nome da sessão"
+              type="text"
+              placeholder="Nome da sessão"
+              value={form.nome}
+              onChange={(e) => onSessionNameChange(e.target.value)}
+              required
+              error={form.fieldErrors.nomeSessao}
+            />
 
-          <label className={styles.label} htmlFor="session-date-time">
-            Data e hora <span className={styles.required}>*</span>
-          </label>
-          <input
-            id="session-date-time"
-            type="datetime-local"
-            className={styles.input}
-            value={form.dataHora}
-            onChange={(e) => onSessionDateTimeChange(e.target.value)}
-            required
-          />
-          {form.fieldErrors.dataHoraSessao && (
-            <p className={styles.errorText}>{form.fieldErrors.dataHoraSessao}</p>
-          )}
+            <TextField
+              id="session-date-time"
+              label="Data e hora"
+              type="datetime-local"
+              value={form.dataHora}
+              onChange={(e) => onSessionDateTimeChange(e.target.value)}
+              required
+              error={form.fieldErrors.dataHoraSessao}
+            />
 
-          <label className={styles.label} htmlFor="session-status">Status da sessão</label>
-          <select
-            id="session-status"
-            className={styles.select}
-            value={form.status}
-            onChange={(e) => onSessionStatusChange(e.target.value as SessionStatus)}
-          >
-            {SESSION_STATUS_OPTIONS.map((status) => (
-              <option key={status} value={status}>
-                {status === "ATIVO" ? "Ativo" : status === "ESGOTADO" ? "Esgotado" : "Cancelado"}
-              </option>
-            ))}
-          </select>
-          {form.fieldErrors.statusSessao && <p className={styles.errorText}>{form.fieldErrors.statusSessao}</p>}
+            <SelectField
+              id="session-status"
+              label="Status da sessão"
+              value={form.status}
+              onChange={(e) => onSessionStatusChange(e.target.value as SessionStatus)}
+              error={form.fieldErrors.statusSessao}
+            >
+              {SESSION_STATUS_OPTIONS.map((status) => (
+                <option key={status} value={status}>
+                  {status === "ATIVO" ? "Ativo" : status === "ESGOTADO" ? "Esgotado" : "Cancelado"}
+                </option>
+              ))}
+            </SelectField>
 
-          <label className={styles.label} htmlFor="session-capacity">Capacidade da sessão</label>
-          <input
-            id="session-capacity"
-            type="number"
-            className={styles.input}
-            placeholder="Capacidade (opcional)"
-            min="1"
-            step="1"
-            value={form.capacidade}
-            onChange={(e) => onSessionCapacityChange(e.target.value)}
-          />
-          {form.fieldErrors.capacidade && <p className={styles.errorText}>{form.fieldErrors.capacidade}</p>}
-          {form.formError && <p className={styles.errorText}>{form.formError}</p>}
+            <TextField
+              id="session-capacity"
+              label="Capacidade da sessão"
+              type="number"
+              placeholder="Capacidade (opcional)"
+              min="1"
+              step="1"
+              value={form.capacidade}
+              onChange={(e) => onSessionCapacityChange(e.target.value)}
+              error={form.fieldErrors.capacidade}
+            />
+            {form.formError && <p className={styles.errorText}>{form.formError}</p>}
 
-          <button type="submit" className={styles.btnSave}>
-            {form.editando ? "Atualizar Sessão" : "Criar Sessão"}
-          </button>
-        </form>
+            <Button type="submit">
+              {form.editando ? "Atualizar Sessão" : "Criar Sessão"}
+            </Button>
+          </form>
+        </Card>
       )}
     </div>
   );

--- a/frontend/app/dashboard/eventos/[id]/_components/TicketTypesManager.tsx
+++ b/frontend/app/dashboard/eventos/[id]/_components/TicketTypesManager.tsx
@@ -1,4 +1,5 @@
 import { FormEvent } from "react";
+import { Button, Card, SelectField, TextField } from "@/components/ui";
 import { SessaoEventoResponse, TipoIngressoResponse } from "@/services/types";
 import { TicketTypeFieldErrors } from "../_utils/eventDetailsTypes";
 import styles from "../page.module.css";
@@ -46,11 +47,9 @@ export default function TicketTypesManager({
       <h2 className={styles.sectionTitle}>Tipos de Ingresso</h2>
 
       {sessoes.length > 0 && (
-        <>
-          <label className={styles.label} htmlFor="ticket-session-select">Sessão</label>
-          <select
+        <SelectField
             id="ticket-session-select"
-            className={styles.select}
+            label="Sessão"
             value={sessaoSelecionada ?? ""}
             onChange={(e) => onSelectedSessionChange(Number(e.target.value))}
           >
@@ -59,8 +58,7 @@ export default function TicketTypesManager({
                 {sessao.nomeSessao}
               </option>
             ))}
-          </select>
-        </>
+        </SelectField>
       )}
 
       {loadingTipos && <p className={styles.feedback}>Carregando tipos de ingresso...</p>}
@@ -87,78 +85,66 @@ export default function TicketTypesManager({
       )}
 
       {isAdmin && sessaoSelecionada && (
-        <form onSubmit={onSubmitTicketType} className={styles.formCard} noValidate>
-          <h3>Novo Tipo de Ingresso</h3>
+        <Card className={styles.inlineFormCard}>
+          <form onSubmit={onSubmitTicketType} noValidate>
+            <h3>Novo Tipo de Ingresso</h3>
 
-          <label className={styles.label} htmlFor="ticket-sector">
-            Setor <span className={styles.required}>*</span>
-          </label>
-          <input
-            id="ticket-sector"
-            type="text"
-            className={styles.input}
-            placeholder="Setor"
-            value={form.nomeSetor}
-            onChange={(e) => onSectorChange(e.target.value)}
-            required
-          />
-          {form.fieldErrors.nomeSetor && <p className={styles.errorText}>{form.fieldErrors.nomeSetor}</p>}
+            <TextField
+              id="ticket-sector"
+              label="Setor"
+              type="text"
+              placeholder="Setor"
+              value={form.nomeSetor}
+              onChange={(e) => onSectorChange(e.target.value)}
+              required
+              error={form.fieldErrors.nomeSetor}
+            />
 
-          <label className={styles.label} htmlFor="ticket-price">
-            Preço <span className={styles.required}>*</span>
-          </label>
-          <input
-            id="ticket-price"
-            type="number"
-            className={styles.input}
-            placeholder="Preço"
-            min="0"
-            step="0.01"
-            value={form.preco}
-            onChange={(e) => onPriceChange(e.target.value)}
-            required
-          />
-          {form.fieldErrors.preco && <p className={styles.errorText}>{form.fieldErrors.preco}</p>}
+            <TextField
+              id="ticket-price"
+              label="Preço"
+              type="number"
+              placeholder="Preço"
+              min="0"
+              step="0.01"
+              value={form.preco}
+              onChange={(e) => onPriceChange(e.target.value)}
+              required
+              error={form.fieldErrors.preco}
+            />
 
-          <label className={styles.label} htmlFor="ticket-quantity">
-            Quantidade total <span className={styles.required}>*</span>
-          </label>
-          <input
-            id="ticket-quantity"
-            type="number"
-            className={styles.input}
-            placeholder="Quantidade total"
-            min="1"
-            step="1"
-            value={form.quantidadeTotal}
-            onChange={(e) => onQuantityChange(e.target.value)}
-            required
-          />
-          {form.fieldErrors.quantidadeTotal && (
-            <p className={styles.errorText}>{form.fieldErrors.quantidadeTotal}</p>
-          )}
+            <TextField
+              id="ticket-quantity"
+              label="Quantidade total"
+              type="number"
+              placeholder="Quantidade total"
+              min="1"
+              step="1"
+              value={form.quantidadeTotal}
+              onChange={(e) => onQuantityChange(e.target.value)}
+              required
+              error={form.fieldErrors.quantidadeTotal}
+            />
 
-          <label className={styles.label} htmlFor="ticket-lot">
-            Lote <span className={styles.required}>*</span>
-          </label>
-          <input
-            id="ticket-lot"
-            type="number"
-            className={styles.input}
-            placeholder="Lote"
-            min="1"
-            step="1"
-            value={form.lote}
-            onChange={(e) => onLotChange(e.target.value)}
-            required
-          />
-          {form.fieldErrors.lote && <p className={styles.errorText}>{form.fieldErrors.lote}</p>}
-          {form.formError && <p className={styles.errorText}>{form.formError}</p>}
+            <TextField
+              id="ticket-lot"
+              label="Lote"
+              type="number"
+              placeholder="Lote"
+              min="1"
+              step="1"
+              value={form.lote}
+              onChange={(e) => onLotChange(e.target.value)}
+              required
+              error={form.fieldErrors.lote}
+            />
+            {form.formError && <p className={styles.errorText}>{form.formError}</p>}
 
-          <button type="submit" className={styles.btnSave}>
-            Criar Tipo
-          </button>
-        </form>
+            <Button type="submit">
+              Criar Tipo
+            </Button>
+          </form>
+        </Card>
       )}
     </div>
   );

--- a/frontend/app/dashboard/eventos/[id]/page.module.css
+++ b/frontend/app/dashboard/eventos/[id]/page.module.css
@@ -42,44 +42,16 @@
   font-size: 1rem;
 }
 
-.badge {
-  display: inline-flex;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 500;
-}
-
-.ativo {
-  background-color: var(--success-bg);
-  color: var(--success-text);
-}
-
-.cancelado {
-  background-color: var(--danger-bg);
-  color: var(--danger-text);
-}
-
-.finalizado {
-  background-color: var(--neutral-bg);
-  color: var(--neutral-text);
-}
-
-.formCard,
-.errorCard {
-  background: white;
-  border-radius: 12px;
-  border: 1px solid var(--border-color);
-  padding: 2.5rem;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
-}
-
 .errorCard {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
   color: var(--danger-text);
+}
+
+.inlineFormCard {
+  margin-top: 1.5rem;
 }
 
 .section {
@@ -95,10 +67,6 @@
   border-bottom: 1px solid var(--border-color);
 }
 
-.formGroup {
-  margin-bottom: 1.5rem;
-}
-
 .row {
   display: flex;
   gap: 1.5rem;
@@ -107,48 +75,6 @@
 
 .col {
   flex: 1;
-}
-
-.label {
-  display: block;
-  font-size: 0.95rem;
-  color: var(--text-main);
-  margin-bottom: 0.5rem;
-}
-
-.required {
-  color: var(--danger-text);
-}
-
-.input,
-.textarea,
-.select {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  font-size: 0.95rem;
-  outline: none;
-  transition: all 0.2s ease;
-  color: var(--text-main);
-  background-color: white;
-}
-
-.textarea {
-  resize: vertical;
-  min-height: 120px;
-}
-
-.input::placeholder,
-.textarea::placeholder {
-  color: #9ca3af;
-}
-
-.input:focus,
-.textarea:focus,
-.select:focus {
-  border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px rgba(26, 92, 255, 0.1);
 }
 
 .feedback,
@@ -161,60 +87,6 @@
   color: var(--danger-text);
 }
 
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 1rem;
-  margin-top: 3rem;
-}
-
-.btnCancel,
-.btnSave,
-.btnDelete {
-  padding: 0.75rem 1.5rem;
-  border-radius: 8px;
-  font-weight: 500;
-  font-size: 0.95rem;
-  transition: background-color 0.2s, border-color 0.2s, opacity 0.2s;
-}
-
-.btnCancel {
-  background-color: white;
-  border: 1px solid var(--border-color);
-  color: var(--text-main);
-}
-
-.btnCancel:hover:not(:disabled) {
-  background-color: var(--neutral-bg);
-}
-
-.btnSave {
-  background-color: var(--primary-blue);
-  color: white;
-  border: none;
-}
-
-.btnSave:hover:not(:disabled) {
-  background-color: var(--primary-hover);
-}
-
-.btnDelete {
-  background-color: white;
-  border: 1px solid var(--danger-text);
-  color: var(--danger-text);
-}
-
-.btnDelete:hover:not(:disabled) {
-  background-color: var(--danger-bg);
-}
-
-.btnCancel:disabled,
-.btnSave:disabled,
-.btnDelete:disabled {
-  cursor: not-allowed;
-  opacity: 0.65;
-}
-
 @media (max-width: 768px) {
   .header,
   .row,
@@ -222,19 +94,18 @@
     flex-direction: column;
   }
 
-  .btnDelete,
-  .actions,
-  .actions button {
+  .header button,
+  .actionsInline,
+  .actionsInline button {
     width: 100%;
   }
 
-  .actions {
-    flex-direction: column-reverse;
+  .actionsInline {
+    flex-direction: column;
   }
 
-  .formCard,
   .errorCard {
-    padding: 1.5rem;
+    align-items: stretch;
   }
 }
 

--- a/frontend/app/dashboard/eventos/[id]/page.tsx
+++ b/frontend/app/dashboard/eventos/[id]/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import ConfirmDialog from "@/components/ConfirmDialog";
+import { Badge, Button, Card } from "@/components/ui";
 import { usePermissions } from "@/hooks/useAuthUser";
 import EventForm from "./_components/EventForm";
 import SessionsManager from "./_components/SessionsManager";
@@ -15,6 +16,12 @@ const statusLabelMap: Record<EventoStatus, string> = {
   ATIVO: "Ativo",
   CANCELADO: "Cancelado",
   FINALIZADO: "Finalizado",
+};
+
+const statusVariantMap: Record<EventoStatus, "success" | "danger" | "neutral"> = {
+  ATIVO: "success",
+  CANCELADO: "danger",
+  FINALIZADO: "neutral",
 };
 
 export default function EventDetails() {
@@ -35,12 +42,12 @@ export default function EventDetails() {
         <div className={styles.breadcrumbs}>
           <Link href="/dashboard">Eventos</Link> &gt; <span>Detalhes</span>
         </div>
-        <div className={styles.errorCard}>
+        <Card className={styles.errorCard}>
           <p>{error}</p>
-          <button className={styles.btnCancel} onClick={controller.eventHandlers.goBack}>
+          <Button variant="secondary" onClick={controller.eventHandlers.goBack}>
             Voltar ao dashboard
-          </button>
-        </div>
+          </Button>
+        </Card>
       </div>
     );
   }
@@ -53,21 +60,21 @@ export default function EventDetails() {
 
       <div className={styles.header}>
         <div>
-          <span className={`${styles.badge} ${styles[form.status.toLowerCase()]}`}>
+          <Badge variant={statusVariantMap[form.status]}>
             {statusLabelMap[form.status]}
-          </span>
+          </Badge>
           <h1 className={styles.title}>Detalhes do Evento</h1>
           <p className={styles.subtitle}>Visualize, edite ou exclua este evento.</p>
         </div>
         {isAdmin && (
-          <button
+          <Button
             type="button"
-            className={styles.btnDelete}
+            variant="danger"
             onClick={controller.eventHandlers.handleDelete}
             disabled={controller.deleting || controller.saving}
           >
             {controller.deleting ? "Excluindo..." : "Excluir Evento"}
-          </button>
+          </Button>
         )}
       </div>
 

--- a/frontend/app/page.module.css
+++ b/frontend/app/page.module.css
@@ -43,116 +43,19 @@
   font-size: 0.95rem;
 }
 
-.card {
-  background: var(--card-bg);
-  padding: 2.5rem;
-  border-radius: 16px;
+.authCard {
   width: 100%;
   max-width: 440px;
-  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05), 0 8px 10px -6px rgba(0, 0, 0, 0.01);
-  border: 1px solid rgba(229, 231, 235, 0.5);
   margin-bottom: 1.5rem;
 }
 
-.cardTitle {
-  font-size: 1.35rem;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
-}
-
-.cardSubtitle {
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  margin-bottom: 2rem;
-}
-
-.formGroup {
-  margin-bottom: 1.25rem;
-}
-
-.label {
-  display: block;
-  font-size: 0.9rem;
-  color: var(--text-main);
-  margin-bottom: 0.5rem;
-}
-
-.inputWrapper {
-  position: relative;
-}
-
-.input {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  font-size: 0.95rem;
-  outline: none;
-  transition: all 0.2s ease;
-  color: var(--text-main);
-}
-
-.input::placeholder {
-  color: #9ca3af;
-}
-
-.input:focus {
-  border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px rgba(26, 92, 255, 0.1);
-}
-
-.eyeIcon {
-  position: absolute;
-  right: 1rem;
-  top: 50%;
-  transform: translateY(-50%);
-  color: #9ca3af;
-  cursor: pointer;
-}
-
-.forgotPassword {
-  display: block;
-  text-align: right;
-  font-size: 0.85rem;
-  color: var(--primary-blue);
-  margin-top: 0.5rem;
-}
-
-.forgotPassword:hover {
-  text-decoration: underline;
-}
-
-.button {
-  width: 100%;
-  padding: 0.875rem;
-  background-color: var(--primary-blue);
-  color: white;
-  border-radius: 8px;
-  font-size: 1rem;
-  font-weight: 500;
+.submitButton {
   margin-top: 1rem;
-  transition: background-color 0.2s ease;
 }
 
-.button:hover {
-  background-color: var(--primary-hover);
-}
-
-.demoBox {
-  background-color: rgba(26, 92, 255, 0.05);
-  border: 1px solid rgba(26, 92, 255, 0.1);
-  color: var(--primary-blue);
-  padding: 0.75rem 2rem;
-  border-radius: 12px;
+.formError {
+  color: var(--danger-text);
   font-size: 0.85rem;
-  font-weight: 500;
-}
-
-.forgotPasswordDisabled {
-  display: block;
-  text-align: right;
-  font-size: 0.85rem;
-  color: var(--text-muted);
   margin-top: 0.5rem;
 }
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,6 +7,7 @@ import { login } from "@/services/auth";
 import { storeToken } from "@/lib/authToken";
 import styles from "./page.module.css";
 import { useToast } from "@/components/ToastProvider";
+import { Button, Card, TextField } from "@/components/ui";
 
 export default function Login() {
   const router = useRouter();
@@ -87,70 +88,56 @@ export default function Login() {
           <p className={styles.subtitle}>Plataforma de venda de ingressos</p>
         </div>
 
-        <div className={styles.card}>
-          <h2 className={styles.cardTitle}>Entrar na sua conta</h2>
-          <p className={styles.cardSubtitle}>Bem-vindo de volta! Faça login para continuar.</p>
-
+        <Card
+          title="Entrar na sua conta"
+          subtitle="Bem-vindo de volta! Faça login para continuar."
+          className={styles.authCard}
+        >
           <form onSubmit={handleLogin}>
-            <div className={styles.formGroup}>
-              <label className={styles.label} htmlFor="login-email">Email</label>
-              <div className={styles.inputWrapper}>
-                <input
-                    id="login-email"
-                    type="email"
-                    className={styles.input}
-                    placeholder="seu@email.com"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    aria-invalid={Boolean(error)}
-                    aria-describedby={error ? "login-error" : undefined}
-                />
-              </div>
-            </div>
+            <TextField
+              id="login-email"
+              label="Email"
+              type="email"
+              placeholder="seu@email.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
 
-            <div className={styles.formGroup}>
-              <label className={styles.label} htmlFor="login-password">Senha</label>
-              <div className={styles.inputWrapper}>
-                <input
-                    id="login-password"
-                    type="password"
-                    className={styles.input}
-                    placeholder="••••••••"
-                    value={senha}
-                    onChange={(e) => setSenha(e.target.value)}
-                    aria-invalid={Boolean(error)}
-                    aria-describedby={error ? "login-error login-password-help" : "login-password-help"}
-                />
+            <TextField
+              id="login-password"
+              label="Senha"
+              type="password"
+              placeholder="••••••••"
+              value={senha}
+              onChange={(e) => setSenha(e.target.value)}
+              helpText="Recuperação de senha temporariamente indisponível"
+              trailingIcon={
                 <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className={styles.eyeIcon}
-                    aria-hidden="true"
-                    focusable="false"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                  focusable="false"
                 >
                   <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
                   <circle cx="12" cy="12" r="3" />
                 </svg>
-              </div>
-              <span id="login-password-help" className={styles.forgotPasswordDisabled}>
-                Recuperação de senha temporariamente indisponível
-              </span>
-            </div>
+              }
+            />
 
-            {error && <p id="login-error" className={styles.errorText}>{error}</p>}
+            {error && <p id="login-error" className={styles.formError}>{error}</p>}
 
-            <button type="submit" className={styles.button} disabled={loading}>
+            <Button type="submit" fullWidth disabled={loading} className={styles.submitButton}>
               {loading ? "Entrando..." : "Entrar"}
-            </button>
+            </Button>
           </form>
-        </div>
+        </Card>
 
         <div className={styles.registerLink}>
           Não tem conta? <Link href="/register">Cadastre-se</Link>

--- a/frontend/app/register/page.module.css
+++ b/frontend/app/register/page.module.css
@@ -43,112 +43,17 @@
     font-size: 0.95rem;
 }
 
-.card {
-    background: var(--card-bg);
-    padding: 2.5rem;
-    border-radius: 16px;
+.authCard {
     width: 100%;
     max-width: 440px;
-    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05), 0 8px 10px -6px rgba(0, 0, 0, 0.01);
-    border: 1px solid rgba(229, 231, 235, 0.5);
     margin-bottom: 1.5rem;
 }
 
-.cardTitle {
-    font-size: 1.35rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-}
-
-.cardSubtitle {
-    color: var(--text-muted);
-    font-size: 0.9rem;
-    margin-bottom: 2rem;
-}
-
-.formGroup {
-    margin-bottom: 1.25rem;
-}
-
-.label {
-    display: block;
-    font-size: 0.9rem;
-    color: var(--text-main);
-    margin-bottom: 0.5rem;
-}
-
-.inputWrapper {
-    position: relative;
-}
-
-.input {
-    width: 100%;
-    padding: 0.75rem 1rem;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    font-size: 0.95rem;
-    outline: none;
-    transition: all 0.2s ease;
-    color: var(--text-main);
-}
-
-.input::placeholder {
-    color: #9ca3af;
-}
-
-.input:focus {
-    border-color: var(--primary-blue);
-    box-shadow: 0 0 0 3px rgba(26, 92, 255, 0.1);
-}
-
-.eyeIcon {
-    position: absolute;
-    right: 1rem;
-    top: 50%;
-    transform: translateY(-50%);
-    color: #9ca3af;
-    cursor: pointer;
-}
-
-.forgotPassword {
-    display: block;
-    text-align: right;
-    font-size: 0.85rem;
-    color: var(--primary-blue);
-    margin-top: 0.5rem;
-}
-
-.forgotPassword:hover {
-    text-decoration: underline;
-}
-
-.button {
-    width: 100%;
-    padding: 0.875rem;
-    background-color: var(--primary-blue);
-    color: white;
-    border-radius: 8px;
-    font-size: 1rem;
-    font-weight: 500;
+.submitButton {
     margin-top: 1rem;
-    transition: background-color 0.2s ease;
 }
 
-.button:hover {
-    background-color: var(--primary-hover);
-}
-
-.demoBox {
-    background-color: rgba(26, 92, 255, 0.05);
-    border: 1px solid rgba(26, 92, 255, 0.1);
-    color: var(--primary-blue);
-    padding: 0.75rem 2rem;
-    border-radius: 12px;
-    font-size: 0.85rem;
-    font-weight: 500;
-}
-
-.errorText {
+.formError {
     color: #dc2626;
     font-size: 0.85rem;
     margin-top: 0.5rem;

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -7,6 +7,7 @@ import { isAxiosError } from "axios";
 import { register } from "@/services/auth";
 import { ApiProblemDetail, RegisterRequest } from "@/services/types";
 import { useToast } from "@/components/ToastProvider";
+import { Button, Card, TextField } from "@/components/ui";
 import styles from "./page.module.css";
 
 type FieldErrors = Partial<Record<keyof RegisterRequest, string>>;
@@ -130,162 +131,86 @@ export default function Register() {
                 <p className={styles.subtitle}>Crie sua conta para continuar</p>
             </div>
 
-            <div className={styles.card}>
-                <h2 className={styles.cardTitle}>Cadastro de usuário</h2>
-                <p className={styles.cardSubtitle}>Preencha seus dados para criar a conta.</p>
-
+            <Card
+                title="Cadastro de usuário"
+                subtitle="Preencha seus dados para criar a conta."
+                className={styles.authCard}
+            >
                 <form onSubmit={handleSubmit} noValidate>
-                    <div className={styles.formGroup}>
-                        <label className={styles.label} htmlFor="register-nome">Nome</label>
-                        <div className={styles.inputWrapper}>
-                            <input
-                                id="register-nome"
-                                type="text"
-                                className={styles.input}
-                                placeholder="Seu nome completo"
-                                value={form.nome}
-                                onChange={(e) => updateField("nome", e.target.value)}
-                                aria-invalid={Boolean(fieldErrors.nome)}
-                                aria-describedby={fieldErrors.nome ? "register-nome-error" : undefined}
-                            />
-                        </div>
-                        {fieldErrors.nome && (
-                            <p id="register-nome-error" className={styles.errorText}>{fieldErrors.nome}</p>
-                        )}
-                    </div>
+                    <TextField
+                        id="register-nome"
+                        label="Nome"
+                        type="text"
+                        placeholder="Seu nome completo"
+                        value={form.nome}
+                        onChange={(e) => updateField("nome", e.target.value)}
+                        error={fieldErrors.nome}
+                    />
+                    <TextField
+                        id="register-cpf"
+                        label="CPF"
+                        type="text"
+                        placeholder="Somente números"
+                        value={form.CPF}
+                        onChange={(e) => updateField("CPF", e.target.value)}
+                        error={fieldErrors.CPF}
+                    />
+                    <TextField
+                        id="register-data-nascimento"
+                        label="Data de nascimento"
+                        type="date"
+                        value={form.dataNascimento}
+                        onChange={(e) => updateField("dataNascimento", e.target.value)}
+                        error={fieldErrors.dataNascimento}
+                    />
+                    <TextField
+                        id="register-email"
+                        label="Email"
+                        type="email"
+                        placeholder="seu@email.com"
+                        value={form.email}
+                        onChange={(e) => updateField("email", e.target.value)}
+                        error={fieldErrors.email}
+                    />
+                    <TextField
+                        id="register-senha"
+                        label="Senha"
+                        type="password"
+                        placeholder="••••••••"
+                        value={form.senha}
+                        onChange={(e) => updateField("senha", e.target.value)}
+                        error={fieldErrors.senha}
+                    />
+                    <TextField
+                        id="register-endereco"
+                        label="Endereço"
+                        type="text"
+                        placeholder="Rua, número, bairro"
+                        value={form.endereco}
+                        onChange={(e) => updateField("endereco", e.target.value)}
+                        error={fieldErrors.endereco}
+                    />
+                    <TextField
+                        id="register-telefone"
+                        label="Telefone"
+                        type="text"
+                        placeholder="(11) 98888-7777"
+                        value={form.telefone}
+                        onChange={(e) => updateField("telefone", e.target.value)}
+                        error={fieldErrors.telefone}
+                    />
 
-                    <div className={styles.formGroup}>
-                        <label className={styles.label} htmlFor="register-cpf">CPF</label>
-                        <div className={styles.inputWrapper}>
-                            <input
-                                id="register-cpf"
-                                type="text"
-                                className={styles.input}
-                                placeholder="Somente números"
-                                value={form.CPF}
-                                onChange={(e) => updateField("CPF", e.target.value)}
-                                aria-invalid={Boolean(fieldErrors.CPF)}
-                                aria-describedby={fieldErrors.CPF ? "register-cpf-error" : undefined}
-                            />
-                        </div>
-                        {fieldErrors.CPF && (
-                            <p id="register-cpf-error" className={styles.errorText}>{fieldErrors.CPF}</p>
-                        )}
-                    </div>
+                    {error && <p id="register-form-error" className={styles.formError}>{error}</p>}
 
-                    <div className={styles.formGroup}>
-                        <label className={styles.label} htmlFor="register-data-nascimento">Data de nascimento</label>
-                        <div className={styles.inputWrapper}>
-                            <input
-                                id="register-data-nascimento"
-                                type="date"
-                                className={styles.input}
-                                value={form.dataNascimento}
-                                onChange={(e) => updateField("dataNascimento", e.target.value)}
-                                aria-invalid={Boolean(fieldErrors.dataNascimento)}
-                                aria-describedby={
-                                    fieldErrors.dataNascimento ? "register-data-nascimento-error" : undefined
-                                }
-                            />
-                        </div>
-                        {fieldErrors.dataNascimento && (
-                            <p id="register-data-nascimento-error" className={styles.errorText}>
-                                {fieldErrors.dataNascimento}
-                            </p>
-                        )}
-                    </div>
-
-                    <div className={styles.formGroup}>
-                        <label className={styles.label} htmlFor="register-email">Email</label>
-                        <div className={styles.inputWrapper}>
-                            <input
-                                id="register-email"
-                                type="email"
-                                className={styles.input}
-                                placeholder="seu@email.com"
-                                value={form.email}
-                                onChange={(e) => updateField("email", e.target.value)}
-                                aria-invalid={Boolean(fieldErrors.email)}
-                                aria-describedby={fieldErrors.email ? "register-email-error" : undefined}
-                            />
-                        </div>
-                        {fieldErrors.email && (
-                            <p id="register-email-error" className={styles.errorText}>{fieldErrors.email}</p>
-                        )}
-                    </div>
-
-                    <div className={styles.formGroup}>
-                        <label className={styles.label} htmlFor="register-senha">Senha</label>
-                        <div className={styles.inputWrapper}>
-                            <input
-                                id="register-senha"
-                                type="password"
-                                className={styles.input}
-                                placeholder="••••••••"
-                                value={form.senha}
-                                onChange={(e) => updateField("senha", e.target.value)}
-                                aria-invalid={Boolean(fieldErrors.senha)}
-                                aria-describedby={fieldErrors.senha ? "register-senha-error" : undefined}
-                            />
-                        </div>
-                        {fieldErrors.senha && (
-                            <p id="register-senha-error" className={styles.errorText}>{fieldErrors.senha}</p>
-                        )}
-                    </div>
-
-                    <div className={styles.formGroup}>
-                        <label className={styles.label} htmlFor="register-endereco">Endereço</label>
-                        <div className={styles.inputWrapper}>
-                            <input
-                                id="register-endereco"
-                                type="text"
-                                className={styles.input}
-                                placeholder="Rua, número, bairro"
-                                value={form.endereco}
-                                onChange={(e) => updateField("endereco", e.target.value)}
-                                aria-invalid={Boolean(fieldErrors.endereco)}
-                                aria-describedby={fieldErrors.endereco ? "register-endereco-error" : undefined}
-                            />
-                        </div>
-                        {fieldErrors.endereco && (
-                            <p id="register-endereco-error" className={styles.errorText}>
-                                {fieldErrors.endereco}
-                            </p>
-                        )}
-                    </div>
-
-                    <div className={styles.formGroup}>
-                        <label className={styles.label} htmlFor="register-telefone">Telefone</label>
-                        <div className={styles.inputWrapper}>
-                            <input
-                                id="register-telefone"
-                                type="text"
-                                className={styles.input}
-                                placeholder="(11) 98888-7777"
-                                value={form.telefone}
-                                onChange={(e) => updateField("telefone", e.target.value)}
-                                aria-invalid={Boolean(fieldErrors.telefone)}
-                                aria-describedby={fieldErrors.telefone ? "register-telefone-error" : undefined}
-                            />
-                        </div>
-                        {fieldErrors.telefone && (
-                            <p id="register-telefone-error" className={styles.errorText}>
-                                {fieldErrors.telefone}
-                            </p>
-                        )}
-                    </div>
-
-                    {error && <p id="register-form-error" className={styles.errorText}>{error}</p>}
-
-                    <button type="submit" className={styles.button} disabled={loading}>
+                    <Button type="submit" fullWidth disabled={loading} className={styles.submitButton}>
                         {loading ? "Cadastrando..." : "Cadastrar"}
-                    </button>
+                    </Button>
 
                     <div className={styles.bottomLink}>
                         Já tem conta? <Link href="/">Entrar</Link>
                     </div>
                 </form>
-            </div>
+            </Card>
         </div>
     );
 }

--- a/frontend/components/ui/index.tsx
+++ b/frontend/components/ui/index.tsx
@@ -1,0 +1,221 @@
+import {
+  ButtonHTMLAttributes,
+  InputHTMLAttributes,
+  ReactNode,
+  SelectHTMLAttributes,
+  TextareaHTMLAttributes,
+  useId,
+} from "react";
+import styles from "./ui.module.css";
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "primary" | "secondary" | "danger";
+  fullWidth?: boolean;
+};
+
+export function Button({ variant = "primary", fullWidth = false, className, ...props }: ButtonProps) {
+  return (
+    <button
+      className={cx(styles.button, styles[variant], fullWidth && styles.fullWidth, className)}
+      {...props}
+    />
+  );
+}
+
+type FieldShellProps = {
+  id?: string;
+  label: ReactNode;
+  required?: boolean;
+  error?: string;
+  helpText?: ReactNode;
+  className?: string;
+  children: (fieldProps: {
+    id: string;
+    describedBy?: string;
+    invalid: boolean;
+  }) => ReactNode;
+};
+
+function FieldShell({ id, label, required, error, helpText, className, children }: FieldShellProps) {
+  const generatedId = useId();
+  const fieldId = id ?? generatedId;
+  const errorId = `${fieldId}-error`;
+  const helpId = `${fieldId}-help`;
+  const describedBy = [error ? errorId : null, helpText ? helpId : null].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <div className={cx(styles.field, className)}>
+      <label className={styles.label} htmlFor={fieldId}>
+        {label} {required && <span className={styles.required}>*</span>}
+      </label>
+      {children({ id: fieldId, describedBy, invalid: Boolean(error) })}
+      {error && (
+        <p id={errorId} className={styles.errorText}>
+          {error}
+        </p>
+      )}
+      {helpText && (
+        <span id={helpId} className={styles.helpText}>
+          {helpText}
+        </span>
+      )}
+    </div>
+  );
+}
+
+type TextFieldProps = Omit<InputHTMLAttributes<HTMLInputElement>, "id"> & {
+  id?: string;
+  label: ReactNode;
+  error?: string;
+  helpText?: ReactNode;
+  trailingIcon?: ReactNode;
+  fieldClassName?: string;
+};
+
+export function TextField({
+  id,
+  label,
+  error,
+  helpText,
+  trailingIcon,
+  fieldClassName,
+  className,
+  required,
+  ...props
+}: TextFieldProps) {
+  const hasTrailingIcon = Boolean(trailingIcon);
+
+  return (
+    <FieldShell id={id} label={label} required={required} error={error} helpText={helpText} className={fieldClassName}>
+      {({ id: fieldId, describedBy, invalid }) => (
+        <div className={styles.controlWrap}>
+          <input
+            id={fieldId}
+            className={cx(styles.control, hasTrailingIcon && styles.withTrailing, className)}
+            required={required}
+            aria-invalid={invalid}
+            aria-describedby={describedBy}
+            {...props}
+          />
+          {trailingIcon && <span className={styles.trailing}>{trailingIcon}</span>}
+        </div>
+      )}
+    </FieldShell>
+  );
+}
+
+type SelectFieldProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, "id"> & {
+  id?: string;
+  label: ReactNode;
+  error?: string;
+  helpText?: ReactNode;
+  fieldClassName?: string;
+};
+
+export function SelectField({
+  id,
+  label,
+  error,
+  helpText,
+  fieldClassName,
+  className,
+  required,
+  children,
+  ...props
+}: SelectFieldProps) {
+  return (
+    <FieldShell id={id} label={label} required={required} error={error} helpText={helpText} className={fieldClassName}>
+      {({ id: fieldId, describedBy, invalid }) => (
+        <select
+          id={fieldId}
+          className={cx(styles.control, className)}
+          required={required}
+          aria-invalid={invalid}
+          aria-describedby={describedBy}
+          {...props}
+        >
+          {children}
+        </select>
+      )}
+    </FieldShell>
+  );
+}
+
+type TextareaFieldProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "id"> & {
+  id?: string;
+  label: ReactNode;
+  error?: string;
+  helpText?: ReactNode;
+  fieldClassName?: string;
+};
+
+export function TextareaField({
+  id,
+  label,
+  error,
+  helpText,
+  fieldClassName,
+  className,
+  required,
+  ...props
+}: TextareaFieldProps) {
+  return (
+    <FieldShell id={id} label={label} required={required} error={error} helpText={helpText} className={fieldClassName}>
+      {({ id: fieldId, describedBy, invalid }) => (
+        <textarea
+          id={fieldId}
+          className={cx(styles.control, styles.textarea, className)}
+          required={required}
+          aria-invalid={invalid}
+          aria-describedby={describedBy}
+          {...props}
+        />
+      )}
+    </FieldShell>
+  );
+}
+
+type CardProps = {
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  children: ReactNode;
+  className?: string;
+};
+
+export function Card({ title, subtitle, children, className }: CardProps) {
+  return (
+    <div className={cx(styles.card, className)}>
+      {(title || subtitle) && (
+        <div className={styles.cardHeader}>
+          {title && <h2 className={styles.cardTitle}>{title}</h2>}
+          {subtitle && <p className={styles.cardSubtitle}>{subtitle}</p>}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+type BadgeProps = {
+  children: ReactNode;
+  variant?: "success" | "danger" | "neutral";
+  className?: string;
+};
+
+export function Badge({ children, variant = "neutral", className }: BadgeProps) {
+  const variantClass = {
+    success: styles.badgeSuccess,
+    danger: styles.badgeDanger,
+    neutral: styles.badgeNeutral,
+  }[variant];
+
+  return <span className={cx(styles.badge, variantClass, className)}>{children}</span>;
+}
+
+export function FormActions({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cx(styles.formActions, className)}>{children}</div>;
+}

--- a/frontend/components/ui/ui.module.css
+++ b/frontend/components/ui/ui.module.css
@@ -1,0 +1,219 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 2.75rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  font-size: 0.95rem;
+  font-weight: 500;
+  line-height: 1.2;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(26, 92, 255, 0.18);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.primary {
+  background-color: var(--primary-blue);
+  color: white;
+}
+
+.primary:hover:not(:disabled) {
+  background-color: var(--primary-hover);
+}
+
+.secondary {
+  background-color: white;
+  border-color: var(--border-color);
+  color: var(--text-main);
+}
+
+.secondary:hover:not(:disabled) {
+  background-color: var(--neutral-bg);
+}
+
+.danger {
+  background-color: white;
+  border-color: var(--danger-text);
+  color: var(--danger-text);
+}
+
+.danger:hover:not(:disabled) {
+  background-color: var(--danger-bg);
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.card {
+  width: 100%;
+  padding: 2.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--card-bg);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
+}
+
+.cardHeader {
+  margin-bottom: 2rem;
+}
+
+.cardTitle {
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.cardSubtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.field {
+  margin-bottom: 1.5rem;
+}
+
+.label {
+  display: block;
+  font-size: 0.95rem;
+  color: var(--text-main);
+  margin-bottom: 0.5rem;
+}
+
+.required {
+  color: var(--danger-text);
+}
+
+.controlWrap {
+  position: relative;
+}
+
+.control {
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  outline: none;
+  color: var(--text-main);
+  background-color: white;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, opacity 0.2s ease;
+}
+
+.control::placeholder {
+  color: #9ca3af;
+}
+
+.control:focus {
+  border-color: var(--primary-blue);
+  box-shadow: 0 0 0 3px rgba(26, 92, 255, 0.1);
+}
+
+.control:disabled {
+  cursor: not-allowed;
+  background-color: var(--neutral-bg);
+  color: var(--text-muted);
+  opacity: 0.9;
+}
+
+.control[aria-invalid="true"] {
+  border-color: var(--danger-text);
+}
+
+.control[aria-invalid="true"]:focus {
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.12);
+}
+
+.withTrailing {
+  padding-right: 2.75rem;
+}
+
+.trailing {
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  display: inline-flex;
+  color: #9ca3af;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.helpText,
+.errorText {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.helpText {
+  color: var(--text-muted);
+}
+
+.errorText {
+  color: var(--danger-text);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.badgeSuccess {
+  background-color: var(--success-bg);
+  color: var(--success-text);
+}
+
+.badgeDanger {
+  background-color: var(--danger-bg);
+  color: var(--danger-text);
+}
+
+.badgeNeutral {
+  background-color: var(--neutral-bg);
+  color: var(--neutral-text);
+}
+
+.formActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 3rem;
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 1.5rem;
+  }
+
+  .formActions {
+    flex-direction: column-reverse;
+    gap: 0.75rem;
+  }
+
+  .formActions .button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Cria componentes reutilizáveis de UI para botões, campos, cards, badges e ações de formulário.

Migra login, cadastro, criação de evento e detalhes de evento para usar os componentes base, centralizando estados de foco, erro e disabled. Remove CSS duplicado dos CSS Modules locais.